### PR TITLE
Add binding spec to work around 'UK-18 Introduce a dummy TariffZone_ …

### DIFF
--- a/bindings.xjb
+++ b/bindings.xjb
@@ -68,6 +68,12 @@
 		</jxb:bindings>
 	</jxb:bindings>
 
+	<jxb:bindings
+		schemaLocation="./src/main/resources/xsd/1.10/netex_framework/netex_genericFramework/netex_zone_version.xsd">
+		<jxb:bindings node="//xsd:complexType[@name = 'tariffZonesInFrame_RelStructure']/xsd:complexContent/xsd:extension[@base = 'containmentAggregationStructure']/xsd:sequence/xsd:element[@ref = 'TariffZone_']">
+			<jxb:property name="tariffZone" />
+		</jxb:bindings>
+	</jxb:bindings>
 
 
 


### PR DESCRIPTION
…type to workaround substitutiongroup restrictions  in XML spy'