### PR TITLE
Fix datetime parsing

### DIFF
--- a/src/main/java/org/rutebanken/util/LocalDateTimeISO8601XmlAdapter.java
+++ b/src/main/java/org/rutebanken/util/LocalDateTimeISO8601XmlAdapter.java
@@ -25,7 +25,7 @@ import java.time.temporal.ChronoField;
 public class LocalDateTimeISO8601XmlAdapter extends XmlAdapter<String, LocalDateTime> {
 
 	private static final DateTimeFormatter formatter = new DateTimeFormatterBuilder().appendPattern("yyyy-MM-dd'T'HH:mm:ss")
-			.optionalStart().appendFraction(ChronoField.MILLI_OF_SECOND, 0, 3, true).optionalEnd()
+			.optionalStart().appendFraction(ChronoField.MILLI_OF_SECOND, 0, 9, true).optionalEnd()
 			.optionalStart().appendPattern("XXXXX")
             .optionalEnd()
 			


### PR DESCRIPTION
The specification for xsd:datetime doesn't impose any limit on the
number of digits representing fractions of a second. The limit of 3 is
artificially low and real-life fares data exists that has more than 3
digits