### PR TITLE
Fix parsing duration

### DIFF
--- a/bindings.xjb
+++ b/bindings.xjb
@@ -9,7 +9,6 @@
 <!--			<xjc:javaType name="java.time.LocalDateTime" xmlType="xs:dateTime" adapter="com.migesok.jaxb.adapter.javatime.LocalDateTimeXmlAdapter" />-->
 			<xjc:javaType name="java.time.LocalTime" xmlType="xs:time" adapter="org.rutebanken.util.LocalTimeISO8601XmlAdapter" />
 			<xjc:javaType name="java.time.LocalDateTime" xmlType="xs:date" adapter="org.rutebanken.util.LocalDateXmlAdapter" />
-			<xjc:javaType name="java.time.Duration" xmlType="xs:duration" adapter="com.migesok.jaxb.adapter.javatime.DurationXmlAdapter" />
         </jxb:globalBindings>
 	</jxb:bindings>
 


### PR DESCRIPTION
The provided binding tries to parse an xsd:duration into a
java.time.Duration. That fails for durations that are actually
java.time.Period - ones that are date-based, for example 'P1D'