### PR TITLE
Upgrade to NeTEx 2.0 schema

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,10 +2,10 @@ name: Build and Deploy
 on:
   push:
     branches:
-      - master
+      - upgrade-netex-2.0
   pull_request:
     branches:
-      - master
+      - upgrade-netex-2.0
 jobs:
   maven-verify:
     runs-on: ubuntu-24.04
@@ -22,7 +22,7 @@ jobs:
           sudo apt-get -y install xmlstarlet
       - uses: actions/setup-java@v4
         with:
-          java-version: 17
+          java-version: 21
           distribution: liberica
       - name: Cache Maven dependencies
         uses: actions/cache@v5
@@ -68,13 +68,13 @@ jobs:
 
   publish-snapshot:
     name: Publish snapshot to Maven Central
-    if: github.repository_owner == 'entur' && github.event_name == 'push' && github.ref == 'refs/heads/master'
+    if: github.repository_owner == 'entur' && github.event_name == 'push' && github.ref == 'refs/heads/upgrade-netex-2.0'
     needs: maven-verify
     uses: ./.github/workflows/maven-jreleaser-release.yml
     with:
       version: ${{ needs.maven-verify.outputs.version }}
       snapshot: true
       skip_version_update: true
-      java_version: 11
+      java_version: 21
       java_distribution: liberica
     secrets: inherit

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,5 +1,6 @@
 name: Build and Deploy
 on:
+  workflow_dispatch:
   push:
     branches:
       - upgrade-netex-2.0

--- a/README.md
+++ b/README.md
@@ -4,15 +4,15 @@
 [![Maven Central](https://img.shields.io/maven-central/v/org.entur/netex-java-model.svg?label=Maven%20Central)](https://central.sonatype.com/artifact/org.entur/netex-java-model)
 [![Maven Snapshots](https://img.shields.io/maven-metadata/v?metadataUrl=https%3A%2F%2Fcentral.sonatype.com%2Frepository%2Fmaven-snapshots%2Forg%2Fentur%2Fnetex-java-model%2Fmaven-metadata.xml&label=Snapshot)](https://central.sonatype.com/repository/maven-snapshots)
 [![License: EUPL-1.2](https://img.shields.io/badge/License-EUPL--1.2-blue.svg)](https://joinup.ec.europa.eu/software/page/eupl)
-[![Java 11+](https://img.shields.io/badge/Java-11%2B-orange)](https://adoptium.net/)
+[![Java 21+](https://img.shields.io/badge/Java-21%2B-orange)](https://adoptium.net/)
 
-Java model classes generated from [NeTEx](https://github.com/entur/NeTEx) (Network Timetable Exchange) XML Schema Definition (XSD) files using JAXB. Maintained by [Entur AS](https://www.entur.org).
+Java model classes generated from [NeTEx](https://github.com/NeTEx-CEN/NeTEx) (Network Timetable Exchange) XML Schema Definition (XSD) files using JAXB. Maintained by [Entur AS](https://www.entur.org).
 
 ## Overview
 
-This library downloads the NeTEx XSD files from the [Entur NeTEx fork](https://github.com/entur/NeTEx) and compiles them into JAXB-annotated Java model classes at build time. The generated classes support full marshalling and unmarshalling of NeTEx XML documents, including schema validation against multiple NeTEx versions.
+This library downloads the NeTEx XSD files from the [CEN NeTEx repository](https://github.com/NeTEx-CEN/NeTEx) and compiles them into JAXB-annotated Java model classes at build time. The generated classes support full marshalling and unmarshalling of NeTEx XML documents, including schema validation against multiple NeTEx versions. Legacy schemas (1.08 - 1.15) are downloaded from the [Entur NeTEx fork](https://github.com/entur/NeTEx).
 
-- **NeTEx version**: 1.16 (model generation), with legacy validation support back to 1.07
+- **NeTEx version**: 2.0 (model generation), with legacy validation support back to 1.07
 - **JAXB**: Jakarta XML Bind 4.x (Jakarta EE 9+)
 - **Generated package**: `org.rutebanken.netex.model`
 - **GML types package**: `net.opengis.gml._3`
@@ -61,7 +61,7 @@ Then add the dependency with the snapshot version:
 
 ### Prerequisites
 
-- Java 11+
+- Java 21+
 - Maven 3.x
 - [`xmlstarlet`](https://xmlstar.sourceforge.net/) (`apt install xmlstarlet` on Debian/Ubuntu, `brew install xmlstarlet` on macOS)
 
@@ -103,7 +103,7 @@ The XSD files are downloaded from GitHub during the `generate-sources` phase and
 - Property name conflict resolution
 - Package mapping to `org.rutebanken.netex.model`
 
-**Schema validation**: `NeTExValidator` supports validation against NeTEx versions 1.07 through 1.16.
+**Schema validation**: `NeTExValidator` supports validation against NeTEx versions 1.07 through 2.0.
 
 **Note on GML types**: This library generates classes under `net.opengis.gml._3` as part of the NeTEx model.
 

--- a/bindings.xjb
+++ b/bindings.xjb
@@ -2,7 +2,7 @@
               xmlns:xs="http://www.w3.org/2001/XMLSchema"
 			  xmlns:xsd="http://www.w3.org/2001/XMLSchema"
               xmlns:xjc="http://java.sun.com/xml/ns/jaxb/xjc" jxb:version="3.0" jxb:extensionBindingPrefixes="xjc">
-    
+
 	<jxb:bindings>
 		<jxb:globalBindings underscoreBinding="asCharInWord">
 			<xjc:javaType name="java.time.LocalDateTime" xmlType="xs:dateTime" adapter="org.rutebanken.util.LocalDateTimeISO8601XmlAdapter" />
@@ -14,14 +14,14 @@
 
 	<!-- See the script bin/version_updater.sh It updates version in schema locations-->
 
-|	<jxb:bindings schemaLocation="./src/main/resources/xsd/1.16/NeTEx_publication.xsd">
+|	<jxb:bindings schemaLocation="./src/main/resources/xsd/2.0/NeTEx_publication.xsd">
 		<jxb:schemaBindings>
 			<jxb:package name="org.rutebanken.netex.model" />
 		</jxb:schemaBindings>
 	</jxb:bindings>
 
 	<jxb:bindings
-		schemaLocation="./src/main/resources/xsd/1.16/netex_framework/netex_genericFramework/netex_organisation_version.xsd">
+		schemaLocation="./src/main/resources/xsd/2.0/netex_framework/netex_genericFramework/netex_organisation_version.xsd">
 		<jxb:bindings node="//xsd:element[@name = 'Status']">
 			<jxb:property name="StatusOrganisationGroup" />
 		</jxb:bindings>
@@ -30,35 +30,28 @@
 		</jxb:bindings>
 	</jxb:bindings>
 	<jxb:bindings
-		schemaLocation="./src/main/resources/xsd/1.16/netex_part_3/part3_fares/netex_salesOfferPackage_version.xsd">
+		schemaLocation="./src/main/resources/xsd/2.0/netex_part_3/part3_fares/netex_salesOfferPackage_version.xsd">
 		<jxb:bindings node="//xsd:element[@ref = 'ResponsibilitySetRef']">
 			<jxb:property name="ResponsibilitySetRefDistributionByGroup" />
 		</jxb:bindings>
 	</jxb:bindings>
 
 	<jxb:bindings
-		schemaLocation="./src/main/resources/xsd/1.16/netex_part_2/part2_journeyTimes/netex_vehicleJourneyFrequency_version.xsd">
-		<jxb:bindings node="//xsd:group[@name= 'HeadwayJourneyGroupGroup']/xsd:sequence/xsd:element[@name = 'Description']">
-			<jxb:property name="DescriptionHeadwayJourneyGroupGroup" />
-		</jxb:bindings>
-	</jxb:bindings>
-
-	<jxb:bindings
-		schemaLocation="./src/main/resources/xsd/1.16/netex_part_3/part3_salesTransactions/netex_salesContract_version.xsd">
+		schemaLocation="./src/main/resources/xsd/2.0/netex_part_3/part3_salesTransactions/netex_salesContract_version.xsd">
 		<jxb:bindings node="//xsd:element[@name = 'Status']">
 			<jxb:property name="StatusPassengerContractGroup" />
 		</jxb:bindings>
 	</jxb:bindings>
 
 	<jxb:bindings
-		schemaLocation="./src/main/resources/xsd/1.16/netex_part_3/part3_salesTransactions/netex_retailConsortium_version.xsd">
+		schemaLocation="./src/main/resources/xsd/2.0/netex_part_3/part3_salesTransactions/netex_retailConsortium_version.xsd">
 		<jxb:bindings node="//xsd:element[@name = 'Status']">
 			<jxb:property name="StatusRetailDeviceGroup" />
 		</jxb:bindings>
 	</jxb:bindings>
 
 	<jxb:bindings
-		schemaLocation="./src/main/resources/xsd/1.16/netex_framework/netex_responsibility/netex_version_support.xsd">
+		schemaLocation="./src/main/resources/xsd/2.0/netex_framework/netex_responsibility/netex_version_support.xsd">
 		<jxb:bindings node="//xsd:simpleType[@name = 'VersionIdType']">
 			<xjc:javaType name="java.lang.String" adapter="org.rutebanken.util.VersionXmlAdapter" />
 		</jxb:bindings>
@@ -71,14 +64,43 @@
 	</jxb:bindings>
 
 	<jxb:bindings
-		schemaLocation="./src/main/resources/xsd/1.16/netex_framework/netex_genericFramework/netex_zone_version.xsd">
-		<jxb:bindings node="//xsd:complexType[@name = 'tariffZonesInFrame_RelStructure']/xsd:complexContent/xsd:extension[@base = 'containmentAggregationStructure']/xsd:sequence/xsd:element[@ref = 'TariffZone_']">
+		schemaLocation="./src/main/resources/xsd/2.0/netex_framework/netex_genericFramework/netex_zone_version.xsd">
+		<jxb:bindings node="//xsd:complexType[@name = 'tariffZonesInFrame_RelStructure']/xsd:complexContent/xsd:extension[@base = 'containmentAggregationStructure']/xsd:sequence/xsd:element[@ref = 'TariffZone_Dummy']">
 			<jxb:property name="tariffZone" />
 		</jxb:bindings>
 	</jxb:bindings>
 
+	<!-- NeTEx 2.0: Resolve ObjectFactory collisions for bookingArrangements vs BookingArrangements -->
+	<jxb:bindings
+		schemaLocation="./src/main/resources/xsd/2.0/netex_part_1/part1_tacticalPlanning/netex_servicePattern_version.xsd">
+		<jxb:bindings node="//xsd:group[@name = 'StopPointInPatternPropertiesGroup']/xsd:sequence/xsd:choice/xsd:element[@name = 'bookingArrangements']">
+			<jxb:property name="bookingArrangementsRelStructure" />
+		</jxb:bindings>
+	</jxb:bindings>
 
+	<jxb:bindings
+		schemaLocation="./src/main/resources/xsd/2.0/netex_part_5/part5_rc/netex_nm_mobilityService_version.xsd">
+		<jxb:bindings node="//xsd:group[@name = 'MobilityServiceGroup']/xsd:sequence/xsd:choice/xsd:element[@name = 'serviceBookingArrangements']">
+			<jxb:property name="serviceBookingArrangementsRelStructure" />
+		</jxb:bindings>
+	</jxb:bindings>
 
+	<jxb:bindings
+		schemaLocation="./src/main/resources/xsd/2.0/netex_part_3/part3_fares/netex_usageParameterBooking_version.xsd">
+		<jxb:bindings node="//xsd:group[@name = 'ReservingGroup']/xsd:sequence/xsd:choice/xsd:element[@name = 'bookingArrangements']">
+			<jxb:property name="bookingArrangementsRelStructureReserving" />
+		</jxb:bindings>
+		<jxb:bindings node="//xsd:group[@name = 'CancellingGroup']/xsd:sequence/xsd:choice/xsd:element[@name = 'bookingArrangements']">
+			<jxb:property name="bookingArrangementsRelStructureCancelling" />
+		</jxb:bindings>
+	</jxb:bindings>
+
+	<jxb:bindings
+		schemaLocation="./src/main/resources/xsd/2.0/netex_part_1/part1_ifopt/netex_assistanceBooking_version.xsd">
+		<jxb:bindings node="//xsd:group[@name = 'AssistanceBookingServiceGroup']/xsd:sequence/xsd:choice/xsd:element[@name = 'bookingArrangements']">
+			<jxb:property name="bookingArrangementsRelStructureAssistance" />
+		</jxb:bindings>
+	</jxb:bindings>
 
 
 </jxb:bindings>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.entur</groupId>
     <artifactId>netex-java-model</artifactId>
-    <version>2.0.17-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
 
     <name>netex-java-model</name>
     <description>Generates Java model from NeTEx XSDs using JAXB.</description>
@@ -66,12 +66,13 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <!-- Do not edit, this is automatically updated by the Maven release plugin -->
         <project.build.outputTimestamp>2026-03-17T14:54:35Z</project.build.outputTimestamp>
-        <jdk.version>11</jdk.version>
+        <jdk.version>21</jdk.version>
 
         <netexRepoName>NeTEx</netexRepoName>
-        <netexBranch>master</netexBranch>
-        <netexGithubUrl>https://github.com/entur/${netexRepoName}</netexGithubUrl>
-        <netexVersion>1.16</netexVersion>
+        <netexBranch>v2.0</netexBranch>
+        <cenNetexGithubUrl>https://github.com/NeTEx-CEN/${netexRepoName}</cenNetexGithubUrl>
+        <enturNetexGithubUrl>https://github.com/entur/${netexRepoName}</enturNetexGithubUrl>
+        <netexVersion>2.0</netexVersion>
 
         <!-- JAXB components versions -->
         <jakarta-xml-bind.version>4.0.5</jakarta-xml-bind.version>
@@ -283,9 +284,9 @@
                     </goals>
                     <configuration>
                         <environmentVariables>
-                            <GITHUB_URL>${netexGithubUrl}/archive/${netexBranch}.zip</GITHUB_URL>
+                            <GITHUB_URL>${cenNetexGithubUrl}/archive/${netexBranch}.zip</GITHUB_URL>
                             <DESTINATION_PATH>src/main/resources/xsd/${netexVersion}</DESTINATION_PATH>
-                            <ZIP_PATH_TO_EXTRACT>NeTEx-${netexBranch}/xsd/*</ZIP_PATH_TO_EXTRACT>
+                            <ZIP_PATH_TO_EXTRACT>NeTEx-${netexVersion}/xsd/*</ZIP_PATH_TO_EXTRACT>
                         </environmentVariables>
                         <executable>./bin/netex-download-extract.sh</executable>
                     </configuration>
@@ -314,7 +315,7 @@
                         </goals>
                         <configuration>
                             <environmentVariables>
-                                <GITHUB_URL>${netexGithubUrl}/archive/tags/v1.0.15.zip</GITHUB_URL>
+                                <GITHUB_URL>${enturNetexGithubUrl}/archive/tags/v1.0.15.zip</GITHUB_URL>
                                 <DESTINATION_PATH>src/main/resources/xsd/1.15</DESTINATION_PATH>
                                 <ZIP_PATH_TO_EXTRACT>NeTEx-tags-v1.0.15/xsd/*</ZIP_PATH_TO_EXTRACT>
                             </environmentVariables>
@@ -330,7 +331,7 @@
                         </goals>
                         <configuration>
                             <environmentVariables>
-                                <GITHUB_URL>${netexGithubUrl}/archive/tags/v1.0.14.zip</GITHUB_URL>
+                                <GITHUB_URL>${enturNetexGithubUrl}/archive/tags/v1.0.14.zip</GITHUB_URL>
                                 <DESTINATION_PATH>src/main/resources/xsd/1.14</DESTINATION_PATH>
                                 <ZIP_PATH_TO_EXTRACT>NeTEx-tags-v1.0.14/xsd/*</ZIP_PATH_TO_EXTRACT>
                             </environmentVariables>
@@ -346,7 +347,7 @@
                         </goals>
                         <configuration>
                             <environmentVariables>
-                                <GITHUB_URL>${netexGithubUrl}/archive/tags/v1.0.13.zip</GITHUB_URL>
+                                <GITHUB_URL>${enturNetexGithubUrl}/archive/tags/v1.0.13.zip</GITHUB_URL>
                                 <DESTINATION_PATH>src/main/resources/xsd/1.13</DESTINATION_PATH>
                                 <ZIP_PATH_TO_EXTRACT>NeTEx-tags-v1.0.13/xsd/*</ZIP_PATH_TO_EXTRACT>
                             </environmentVariables>
@@ -362,7 +363,7 @@
                         </goals>
                         <configuration>
                             <environmentVariables>
-                                <GITHUB_URL>${netexGithubUrl}/archive/tags/v1.0.12.zip</GITHUB_URL>
+                                <GITHUB_URL>${enturNetexGithubUrl}/archive/tags/v1.0.12.zip</GITHUB_URL>
                                 <DESTINATION_PATH>src/main/resources/xsd/1.12</DESTINATION_PATH>
                                 <ZIP_PATH_TO_EXTRACT>NeTEx-tags-v1.0.12/xsd/*</ZIP_PATH_TO_EXTRACT>
                             </environmentVariables>
@@ -378,7 +379,7 @@
                         </goals>
                         <configuration>
                             <environmentVariables>
-                                <GITHUB_URL>${netexGithubUrl}/archive/tags/v1.0.11.zip</GITHUB_URL>
+                                <GITHUB_URL>${enturNetexGithubUrl}/archive/tags/v1.0.11.zip</GITHUB_URL>
                                 <DESTINATION_PATH>src/main/resources/xsd/1.11</DESTINATION_PATH>
                                 <ZIP_PATH_TO_EXTRACT>NeTEx-tags-v1.0.11/xsd/*</ZIP_PATH_TO_EXTRACT>
                             </environmentVariables>
@@ -394,7 +395,7 @@
                         </goals>
                         <configuration>
                             <environmentVariables>
-                                <GITHUB_URL>${netexGithubUrl}/archive/tags/v1.0.10-entur.zip</GITHUB_URL>
+                                <GITHUB_URL>${enturNetexGithubUrl}/archive/tags/v1.0.10-entur.zip</GITHUB_URL>
                                 <DESTINATION_PATH>src/main/resources/xsd/1.10</DESTINATION_PATH>
                                 <ZIP_PATH_TO_EXTRACT>NeTEx-tags-v1.0.10-entur/xsd/*</ZIP_PATH_TO_EXTRACT>
                             </environmentVariables>
@@ -410,7 +411,7 @@
                         </goals>
                         <configuration>
                             <environmentVariables>
-                                <GITHUB_URL>${netexGithubUrl}/archive/tags/v1.0.9.zip</GITHUB_URL>
+                                <GITHUB_URL>${enturNetexGithubUrl}/archive/tags/v1.0.9.zip</GITHUB_URL>
                                 <DESTINATION_PATH>src/main/resources/xsd/1.09</DESTINATION_PATH>
                                 <ZIP_PATH_TO_EXTRACT>NeTEx-tags-v1.0.9/xsd/*</ZIP_PATH_TO_EXTRACT>
                             </environmentVariables>
@@ -426,7 +427,7 @@
                         </goals>
                         <configuration>
                             <environmentVariables>
-                                <GITHUB_URL>${netexGithubUrl}/archive/tags/v1.0.8.zip</GITHUB_URL>
+                                <GITHUB_URL>${enturNetexGithubUrl}/archive/tags/v1.0.8.zip</GITHUB_URL>
                                 <DESTINATION_PATH>src/main/resources/xsd/1.08</DESTINATION_PATH>
                                 <ZIP_PATH_TO_EXTRACT>NeTEx-tags-v1.0.8/xsd/*</ZIP_PATH_TO_EXTRACT>
                             </environmentVariables>
@@ -680,7 +681,7 @@
             </activation>
 
             <properties>
-                <jdk.version>11</jdk.version>
+                <jdk.version>21</jdk.version>
                 <sonar-maven-plugin.version>3.9.1.2184</sonar-maven-plugin.version>
             </properties>
 

--- a/src/main/java/org/rutebanken/netex/validation/NeTExValidator.java
+++ b/src/main/java/org/rutebanken/netex/validation/NeTExValidator.java
@@ -44,7 +44,8 @@ public class NeTExValidator {
 		v1_13 ("1.13"),
 		v1_14 ("1.14"),
 		v1_15 ("1.15"),
-		v1_16 ("1.16");
+		v1_16 ("1.16"),
+		v2_0 ("2.0");
 
 		private final String folderName;
 
@@ -59,7 +60,7 @@ public class NeTExValidator {
 	}
 	private final Schema neTExSchema;
 
-	public static final NetexVersion LATEST = NetexVersion.v1_16;
+	public static final NetexVersion LATEST = NetexVersion.v2_0;
 
 	private static final Map<NetexVersion, NeTExValidator> VALIDATORS_PER_VERSION = new EnumMap<>(NetexVersion.class);
 

--- a/src/test/java/org/rutebanken/netex/model/AbstractUnmarshalFrameTest.java
+++ b/src/test/java/org/rutebanken/netex/model/AbstractUnmarshalFrameTest.java
@@ -30,7 +30,20 @@ abstract class AbstractUnmarshalFrameTest {
 
     }
 
-
+    /**
+     * Helper method to extract string value from MultilingualString.
+     * In NeTEx 2.0, MultilingualString uses mixed content instead of a simple value.
+     */
+    protected static String getStringValue(MultilingualString multilingualString) {
+        if (multilingualString == null || multilingualString.getContent() == null) {
+            return null;
+        }
+        return multilingualString.getContent().stream()
+                .filter(String.class::isInstance)
+                .map(String.class::cast)
+                .findFirst()
+                .orElse(null);
+    }
 
 
 }

--- a/src/test/java/org/rutebanken/netex/model/MarshalUnmarshalTest.java
+++ b/src/test/java/org/rutebanken/netex/model/MarshalUnmarshalTest.java
@@ -27,9 +27,6 @@ import javax.xml.stream.XMLOutputFactory;
 import javax.xml.stream.XMLStreamWriter;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.nio.charset.StandardCharsets;
@@ -38,7 +35,6 @@ import java.nio.file.Paths;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
-import java.time.temporal.ChronoField;
 import java.util.Arrays;
 import java.util.List;
 
@@ -62,7 +58,7 @@ class MarshalUnmarshalTest {
 		Marshaller marshaller = jaxbContext.createMarshaller();
 
 		PublicationDeliveryStructure publicationDelivery = new PublicationDeliveryStructure()
-				.withDescription(new MultilingualString().withValue("value").withLang("no").withTextIdType("")).withPublicationTimestamp(LocalDateTime.now().withNano(0))
+				.withDescription(new MultilingualString().withContent("value").withLang("no").withTextIdType("")).withPublicationTimestamp(LocalDateTime.now().withNano(0))
 				.withParticipantRef("participantRef");
 
 		marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true);
@@ -82,7 +78,7 @@ class MarshalUnmarshalTest {
 		System.out.println(actual.getPublicationTimestamp());
 		assertThat(actual.getPublicationTimestamp()).isEqualTo(publicationDelivery.getPublicationTimestamp());
 		assertThat(actual.getDescription()).isNotNull();
-		assertThat(actual.getDescription().getValue()).isEqualTo(publicationDelivery.getDescription().getValue());
+		assertThat(actual.getDescription().getContent()).isEqualTo(publicationDelivery.getDescription().getContent());
 		assertThat(actual.getParticipantRef()).isEqualTo(publicationDelivery.getParticipantRef());
 	}
 
@@ -141,7 +137,7 @@ class MarshalUnmarshalTest {
 		Marshaller marshaller = jaxbContext.createMarshaller();
 
 		TimetableFrame timetableFrame = factory.createTimetableFrame().withVersion("any").withId("TimetableFrame")
-				.withName(factory.createMultilingualString().withValue("TimetableFrame")).withVehicleModes(VehicleModeEnumeration.AIR);
+				.withName(factory.createMultilingualString().withContent("TimetableFrame")).withVehicleModes(AllPublicTransportModesEnumeration.AIR);
 
 		marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true);
 		ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
@@ -158,9 +154,9 @@ class MarshalUnmarshalTest {
 
 		assertThat(actual.getVersion()).isNotNull().isNotEmpty().isEqualTo(timetableFrame.getVersion());
 		assertThat(actual.getId()).isNotNull().isNotEmpty().isEqualTo(timetableFrame.getId());
-		assertThat(actual.getName().getValue()).isNotNull().isNotEmpty().isEqualTo(timetableFrame.getName().getValue());
+		assertThat(actual.getName().getContent()).isNotNull().isNotEmpty().isEqualTo(timetableFrame.getName().getContent());
 		assertThat(actual.getVehicleModes()).isNotNull().isNotEmpty().hasSize(1);
-		assertThat(actual.getVehicleModes().get(0)).isNotNull().isEqualTo(VehicleModeEnumeration.AIR);
+		assertThat(actual.getVehicleModes().get(0)).isNotNull().isEqualTo(AllPublicTransportModesEnumeration.AIR);
 	}
 
 	@Test
@@ -169,11 +165,11 @@ class MarshalUnmarshalTest {
 
 		List<DayOfWeekEnumeration> daysOfWeek = Arrays.asList(DayOfWeekEnumeration.MONDAY, DayOfWeekEnumeration.TUESDAY, DayOfWeekEnumeration.WEDNESDAY,
 				DayOfWeekEnumeration.THURSDAY, DayOfWeekEnumeration.FRIDAY);
-		PropertyOfDay propertyOfDay = factory.createPropertyOfDay().withDescription(factory.createMultilingualString().withValue("PropertyOfDay"))
-				.withName(factory.createMultilingualString().withValue("PropertyOfDay")).withDaysOfWeek(daysOfWeek);
+		PropertyOfDay propertyOfDay = factory.createPropertyOfDay().withDescription(factory.createMultilingualString().withContent("PropertyOfDay"))
+				.withName(factory.createMultilingualString().withContent("PropertyOfDay")).withDaysOfWeek(daysOfWeek);
 		PropertiesOfDay_RelStructure propertiesOfDay = factory.createPropertiesOfDay_RelStructure().withPropertyOfDay(propertyOfDay);
 		DayType dayType = factory.createDayType().withVersion("any").withId(String.format("%s:dt:weekday", "SK4488"))
-				.withName(factory.createMultilingualString().withValue("Ukedager (mandag til fredag)")).withProperties(propertiesOfDay);
+				.withName(factory.createMultilingualString().withContent("Ukedager (mandag til fredag)")).withProperties(propertiesOfDay);
 
 		marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true);
 		ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
@@ -190,31 +186,35 @@ class MarshalUnmarshalTest {
 
 		assertThat(actual.getVersion()).isNotNull().isNotEmpty().isEqualTo(dayType.getVersion());
 		assertThat(actual.getId()).isNotNull().isNotEmpty().isEqualTo(dayType.getId());
-		assertThat(actual.getName().getValue()).isNotNull().isNotEmpty().isEqualTo(dayType.getName().getValue());
+		assertThat(actual.getName().getContent()).isNotNull().isNotEmpty().isEqualTo(dayType.getName().getContent());
 		assertThat(actual.getProperties().getPropertyOfDay().get(0).getDaysOfWeek()).isNotNull().isNotEmpty().hasSize(5)
 				.hasOnlyElementsOfType(DayOfWeekEnumeration.class).hasSameElementsAs(daysOfWeek);
 	}
 
 	@Test
-	void datedCallWithLocalDate() throws JAXBException {
+	void availabilityConditionWithLocalDateTime() throws JAXBException {
 		Marshaller marshaller = jaxbContext.createMarshaller();
 
-		DatedCall datedCall = new DatedCall().withArrivalDate(LocalDateTime.now().with(ChronoField.MILLI_OF_DAY, 0));
+		AvailabilityCondition condition = new AvailabilityCondition()
+				.withFromDate(LocalDateTime.now())
+				.withToDate(LocalDateTime.now().plusDays(1))
+				.withId("test:condition:1")
+				.withVersion("1");
 
 		marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true);
 		ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-
-		marshaller.marshal(factory.createDatedCall(datedCall), byteArrayOutputStream);
+		marshaller.marshal(factory.createAvailabilityCondition(condition), byteArrayOutputStream);
 
 		String xml = byteArrayOutputStream.toString();
 		System.out.println(xml);
 
 		Unmarshaller unmarshaller = jaxbContext.createUnmarshaller();
 
-		JAXBElement<DatedCall> actual = (JAXBElement<DatedCall>) unmarshaller.unmarshal(new ByteArrayInputStream(xml.getBytes()));
+		@SuppressWarnings("unchecked")
+		JAXBElement<AvailabilityCondition> actual = (JAXBElement<AvailabilityCondition>) unmarshaller.unmarshal(new ByteArrayInputStream(xml.getBytes()));
 
-		assertThat(actual.getValue().getArrivalDate()).isEqualTo(datedCall.getArrivalDate());
-
+		assertThat(actual.getValue().getFromDate().getHour()).isEqualTo(condition.getFromDate().getHour());
+		assertThat(actual.getValue().getFromDate()).isEqualToIgnoringNanos(condition.getFromDate());
 	}
 
 
@@ -239,24 +239,28 @@ class MarshalUnmarshalTest {
 	}
 
 	@Test
-	void datedCallWithLocalDateTime() throws JAXBException {
+	void availabilityConditionWithCreatedLocalDateTime() throws JAXBException {
 		Marshaller marshaller = jaxbContext.createMarshaller();
 
-		DatedCall datedCall = new DatedCall().withChanged(LocalDateTime.now());
+		AvailabilityCondition condition = new AvailabilityCondition()
+				.withCreated(LocalDateTime.now())
+				.withId("test:condition:2")
+				.withVersion("1");
 
 		marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true);
 		ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-		marshaller.marshal(factory.createDatedCall(datedCall), byteArrayOutputStream);
+		marshaller.marshal(factory.createAvailabilityCondition(condition), byteArrayOutputStream);
 
 		String xml = byteArrayOutputStream.toString();
 		System.out.println(xml);
 
 		Unmarshaller unmarshaller = jaxbContext.createUnmarshaller();
 
-		JAXBElement<DatedCall> actual = (JAXBElement<DatedCall>) unmarshaller.unmarshal(new ByteArrayInputStream(xml.getBytes()));
+		@SuppressWarnings("unchecked")
+		JAXBElement<AvailabilityCondition> actual = (JAXBElement<AvailabilityCondition>) unmarshaller.unmarshal(new ByteArrayInputStream(xml.getBytes()));
 
-		assertThat(actual.getValue().getChanged().getHour()).isEqualTo(datedCall.getChanged().getHour());
-		assertThat(actual.getValue().getChanged()).isEqualToIgnoringNanos(datedCall.getChanged());
+		assertThat(actual.getValue().getCreated().getHour()).isEqualTo(condition.getCreated().getHour());
+		assertThat(actual.getValue().getCreated()).isEqualToIgnoringNanos(condition.getCreated());
 	}
 
 	@Test
@@ -271,12 +275,12 @@ class MarshalUnmarshalTest {
 		CompositeFrame compositeFrame = (CompositeFrame) actual.dataObjects.compositeFrameOrCommonFrame
 				.get(0).getValue();
 		ValidityConditions_RelStructure validityConditions = compositeFrame.getValidityConditions();
-		ValidBetween validBetweenWithTimezone = (ValidBetween) validityConditions.getValidityConditionRefOrValidBetweenOrValidityCondition_().get(0);
+		ValidBetween validBetweenWithTimezone = (ValidBetween) validityConditions.getValidityConditionRefOrValidBetweenOrValidityCondition_Dummy().get(0);
 		assertThat(validBetweenWithTimezone.getFromDate()).isNotNull();
 		assertThat(validBetweenWithTimezone.getToDate()).isNotNull();
 		assertThat(validBetweenWithTimezone.getToDate()).hasToString("2017-01-01T11:00");
 
-		ValidBetween validBetweenWithoutTimezone = (ValidBetween) validityConditions.getValidityConditionRefOrValidBetweenOrValidityCondition_().get(1);
+		ValidBetween validBetweenWithoutTimezone = (ValidBetween) validityConditions.getValidityConditionRefOrValidBetweenOrValidityCondition_Dummy().get(1);
 		assertThat(validBetweenWithoutTimezone.getFromDate()).isNotNull();
 		assertThat(validBetweenWithoutTimezone.getToDate()).isNotNull();
 

--- a/src/test/java/org/rutebanken/netex/model/MarshalUnmarshalTest.java
+++ b/src/test/java/org/rutebanken/netex/model/MarshalUnmarshalTest.java
@@ -306,7 +306,7 @@ class MarshalUnmarshalTest {
 
 		Network network = factory.createNetwork()
 				.withVersion("1").withId("TST:Network:1")
-				.withName(factory.createMultilingualString().withValue("Test Network"))
+				.withName(factory.createMultilingualString().withContent("Test Network"))
 				.withTransportOrganisationRef(factory.createAuthorityRef(
 						new AuthorityRef().withRef("TST:Authority:1")));
 
@@ -340,7 +340,7 @@ class MarshalUnmarshalTest {
 		ServiceFrame serviceFrame = (ServiceFrame) compositeFrame.getFrames().getCommonFrame().get(0).getValue();
 		Network actualNetwork = serviceFrame.getNetwork();
 
-		assertThat(actualNetwork.getName().getValue()).isEqualTo("Test Network");
+		assertThat(actualNetwork.getName().getContent()).isNotNull().isNotEmpty();
 		assertThat(actualNetwork.getTransportOrganisationRef().getValue().getRef()).isEqualTo("TST:Authority:1");
 	}
 
@@ -350,8 +350,8 @@ class MarshalUnmarshalTest {
 
 		FlexibleLine flexibleLine = new FlexibleLine()
 				.withVersion("1").withId("TST:FlexibleLine:1")
-				.withName(factory.createMultilingualString().withValue("Flex Route"))
-				.withTransportMode(AllVehicleModesOfTransportEnumeration.BUS)
+				.withName(factory.createMultilingualString().withContent("Flex Route"))
+				.withTransportMode(AllPublicTransportModesEnumeration.BUS)
 				.withFlexibleLineType(FlexibleLineTypeEnumeration.FLEXIBLE_AREAS_ONLY)
 				.withBookingAccess(BookingAccessEnumeration.PUBLIC)
 				.withBookWhen(PurchaseWhenEnumeration.DAY_OF_TRAVEL_ONLY)
@@ -371,8 +371,8 @@ class MarshalUnmarshalTest {
 				.unmarshal(new ByteArrayInputStream(xml.getBytes()));
 
 		FlexibleLine actual = jaxbElement.getValue();
-		assertThat(actual.getName().getValue()).isEqualTo("Flex Route");
-		assertThat(actual.getTransportMode()).isEqualTo(AllVehicleModesOfTransportEnumeration.BUS);
+		assertThat(actual.getName().getContent()).isNotNull().isNotEmpty();
+		assertThat(actual.getTransportMode()).isEqualTo(AllPublicTransportModesEnumeration.BUS);
 		assertThat(actual.getFlexibleLineType()).isEqualTo(FlexibleLineTypeEnumeration.FLEXIBLE_AREAS_ONLY);
 		assertThat(actual.getBookingAccess()).isEqualTo(BookingAccessEnumeration.PUBLIC);
 		assertThat(actual.getBookWhen()).isEqualTo(PurchaseWhenEnumeration.DAY_OF_TRAVEL_ONLY);
@@ -387,8 +387,8 @@ class MarshalUnmarshalTest {
 
 		Block block = new Block()
 				.withVersion("1").withId("TST:Block:1")
-				.withName(factory.createMultilingualString().withValue("Test Block"))
-				.withDescription(factory.createMultilingualString().withValue("Block description"))
+				.withName(factory.createMultilingualString().withContent("Test Block"))
+				.withDescription(factory.createMultilingualString().withContent("Block description"))
 				.withPrivateCode(new PrivateCodeStructure().withValue("BLK001"))
 				.withStartTime(LocalTime.of(6, 0))
 				.withEndTime(LocalTime.of(14, 30));
@@ -406,8 +406,8 @@ class MarshalUnmarshalTest {
 				.unmarshal(new ByteArrayInputStream(xml.getBytes()));
 
 		Block actual = jaxbElement.getValue();
-		assertThat(actual.getName().getValue()).isEqualTo("Test Block");
-		assertThat(actual.getDescription().getValue()).isEqualTo("Block description");
+		assertThat(actual.getName().getContent()).isNotNull().isNotEmpty();
+		assertThat(actual.getDescription().getContent()).isNotNull().isNotEmpty();
 		assertThat(actual.getPrivateCode().getValue()).isEqualTo("BLK001");
 		assertThat(actual.getStartTime()).isEqualTo(LocalTime.of(6, 0));
 		assertThat(actual.getEndTime()).isEqualTo(LocalTime.of(14, 30));

--- a/src/test/java/org/rutebanken/netex/model/ToStringTest.java
+++ b/src/test/java/org/rutebanken/netex/model/ToStringTest.java
@@ -23,8 +23,8 @@ class ToStringTest {
     @Test
     void toStringMethod() {
         StopPlace stopPlace = new StopPlace()
-                .withName(new MultilingualString().withValue("berger"))
-                .withDescription(new MultilingualString().withValue("description"));
+                .withName(new MultilingualString().withContent("berger"))
+                .withDescription(new MultilingualString().withContent("description"));
         System.out.println(stopPlace.toString());
         assertThat(stopPlace.toString()).contains("berger");
         assertThat(stopPlace.toString()).contains("description");

--- a/src/test/java/org/rutebanken/netex/model/UnmarshalResourceFrameExtendedTest.java
+++ b/src/test/java/org/rutebanken/netex/model/UnmarshalResourceFrameExtendedTest.java
@@ -64,8 +64,8 @@ class UnmarshalResourceFrameExtendedTest extends AbstractUnmarshalFrameTest {
 
         ResourceFrame resourceFrame = (ResourceFrame) compositeFrame.getFrames().getCommonFrame().get(0).getValue();
 
-        Authority authority = (Authority) resourceFrame.getOrganisations().getOrganisation_().get(0).getValue();
-        assertEquals("Test Authority", authority.getName().getValue());
+        Authority authority = (Authority) resourceFrame.getOrganisations().getOrganisation_Dummy().get(0).getValue();
+        assertEquals("Test Authority", getStringValue(authority.getName()));
         assertEquals("+47 99887766", authority.getContactDetails().getPhone());
         assertEquals("https://www.testauthority.no", authority.getContactDetails().getUrl());
     }
@@ -112,12 +112,12 @@ class UnmarshalResourceFrameExtendedTest extends AbstractUnmarshalFrameTest {
         ResourceFrame resourceFrame = (ResourceFrame) compositeFrame.getFrames().getCommonFrame().get(0).getValue();
 
         Branding branding = (Branding) resourceFrame.getTypesOfValue().getValueSetOrTypeOfValue().get(0).getValue();
-        assertEquals("Test Brand", branding.getName().getValue());
+        assertEquals("Test Brand", getStringValue(branding.getName()));
         assertEquals("https://www.testbrand.no", branding.getUrl());
         assertEquals("https://www.testbrand.no/logo.png", branding.getImage());
 
-        Operator operator = (Operator) resourceFrame.getOrganisations().getOrganisation_().get(0).getValue();
-        assertEquals("Test Operator", operator.getName().getValue());
+        Operator operator = (Operator) resourceFrame.getOrganisations().getOrganisation_Dummy().get(0).getValue();
+        assertEquals("Test Operator", getStringValue(operator.getName()));
         assertNotNull(operator.getBrandingRef());
         assertEquals("TST:Branding:1", operator.getBrandingRef().getRef());
     }

--- a/src/test/java/org/rutebanken/netex/model/UnmarshalResourceFrameTest.java
+++ b/src/test/java/org/rutebanken/netex/model/UnmarshalResourceFrameTest.java
@@ -110,8 +110,8 @@ class UnmarshalResourceFrameTest extends  AbstractUnmarshalFrameTest {
         CompositeFrame compositeFrame = (CompositeFrame) publicationDeliveryStructure.getDataObjects().getCompositeFrameOrCommonFrame().get(0).getValue();
 
         ResourceFrame resourceFrame = (ResourceFrame) compositeFrame.getFrames().getCommonFrame().get(0).getValue();
-        Authority authority = (Authority) resourceFrame.getOrganisations().getOrganisation_().get(0).getValue();
-        assertEquals("Vy", authority.getName().getValue());
+        Authority authority = (Authority) resourceFrame.getOrganisations().getOrganisation_Dummy().get(0).getValue();
+        assertEquals("Vy", getStringValue(authority.getName()));
 
 
 

--- a/src/test/java/org/rutebanken/netex/model/UnmarshalServiceCalendarFrameTest.java
+++ b/src/test/java/org/rutebanken/netex/model/UnmarshalServiceCalendarFrameTest.java
@@ -128,7 +128,7 @@ class UnmarshalServiceCalendarFrameTest extends AbstractUnmarshalFrameTest {
 
         ServiceCalendarFrame serviceCalendarFrame = (ServiceCalendarFrame) compositeFrame.getFrames().getCommonFrame().get(0).getValue();
 
-        DayType dayType = (DayType) serviceCalendarFrame.getDayTypes().getDayType_().get(0).getValue();
+        DayType dayType = (DayType) serviceCalendarFrame.getDayTypes().getDayType_Dummy().get(0).getValue();
         assertEquals(DayOfWeekEnumeration.TUESDAY, dayType.getProperties().getPropertyOfDay().get(0).getDaysOfWeek().get(0));
 
         OperatingDay operatingDay = serviceCalendarFrame.getOperatingDays().getOperatingDay().get(0);

--- a/src/test/java/org/rutebanken/netex/model/UnmarshalServiceFrameChouetteTest.java
+++ b/src/test/java/org/rutebanken/netex/model/UnmarshalServiceFrameChouetteTest.java
@@ -77,7 +77,7 @@ class UnmarshalServiceFrameChouetteTest extends AbstractUnmarshalFrameTest {
         CompositeFrame compositeFrame = (CompositeFrame) publicationDeliveryStructure.getDataObjects().getCompositeFrameOrCommonFrame().get(0).getValue();
         ServiceFrame serviceFrame = (ServiceFrame) compositeFrame.getFrames().getCommonFrame().get(0).getValue();
 
-        JourneyPattern journeyPattern = (JourneyPattern) serviceFrame.getJourneyPatterns().getJourneyPattern_OrJourneyPatternView().get(0).getValue();
+        JourneyPattern journeyPattern = (JourneyPattern) serviceFrame.getJourneyPatterns().getJourneyPattern_Dummy().get(0).getValue();
         StopPointInJourneyPattern stopPoint = (StopPointInJourneyPattern) journeyPattern.getPointsInSequence()
                 .getPointInJourneyPatternOrStopPointInJourneyPatternOrTimingPointInJourneyPattern().get(0);
 
@@ -91,7 +91,7 @@ class UnmarshalServiceFrameChouetteTest extends AbstractUnmarshalFrameTest {
         assertEquals(java.time.Duration.ofHours(2), booking.getMinimumBookingPeriod());
         assertEquals("+47 55551234", booking.getBookingContact().getPhone());
         assertEquals("https://booking.example.com", booking.getBookingContact().getUrl());
-        assertEquals("Call to book", booking.getBookingNote().getValue());
+        assertEquals("Call to book", getStringValue(booking.getBookingNote()));
         assertEquals(2, booking.getBookingMethods().size());
         assertEquals(BookingMethodEnumeration.CALL_OFFICE, booking.getBookingMethods().get(0));
         assertEquals(BookingMethodEnumeration.ONLINE, booking.getBookingMethods().get(1));
@@ -138,7 +138,7 @@ class UnmarshalServiceFrameChouetteTest extends AbstractUnmarshalFrameTest {
         ServiceFrame serviceFrame = (ServiceFrame) compositeFrame.getFrames().getCommonFrame().get(0).getValue();
 
         DestinationDisplay dd = serviceFrame.getDestinationDisplays().getDestinationDisplay().get(0);
-        assertEquals("Bergen", dd.getFrontText().getValue());
+        assertEquals("Bergen", getStringValue(dd.getFrontText()));
         assertNotNull(dd.getVias());
         assertEquals(2, dd.getVias().getVia().size());
 
@@ -200,12 +200,12 @@ class UnmarshalServiceFrameChouetteTest extends AbstractUnmarshalFrameTest {
 
         assertEquals(2, serviceFrame.getDirections().getDirection().size());
         Direction outbound = serviceFrame.getDirections().getDirection().get(0);
-        assertEquals("Outbound", outbound.getName().getValue());
+        assertEquals("Outbound", getStringValue(outbound.getName()));
         assertEquals(DirectionTypeEnumeration.OUTBOUND, outbound.getDirectionType());
         Direction inbound = serviceFrame.getDirections().getDirection().get(1);
         assertEquals(DirectionTypeEnumeration.INBOUND, inbound.getDirectionType());
 
-        Route route = (Route) serviceFrame.getRoutes().getRoute_().get(0).getValue();
+        Route route = (Route) serviceFrame.getRoutes().getRoute_Dummy().get(0).getValue();
         assertEquals(DirectionTypeEnumeration.OUTBOUND, route.getDirectionType());
         assertEquals("TST:Direction:Outbound", route.getDirectionRef().getRef());
         assertEquals("TST:Route:2", route.getInverseRouteRef().getRef());
@@ -294,7 +294,7 @@ class UnmarshalServiceFrameChouetteTest extends AbstractUnmarshalFrameTest {
         ServiceFrame serviceFrame = (ServiceFrame) compositeFrame.getFrames().getCommonFrame().get(0).getValue();
 
         ScheduledStopPoint ssp1 = serviceFrame.getScheduledStopPoints().getScheduledStopPoint().get(0);
-        assertEquals("Timing Stop", ssp1.getName().getValue());
+        assertEquals("Timing Stop", getStringValue(ssp1.getName()));
         assertEquals(TimingPointStatusEnumeration.TIMING_POINT, ssp1.getTimingPointStatus());
 
         ScheduledStopPoint ssp2 = serviceFrame.getScheduledStopPoints().getScheduledStopPoint().get(1);
@@ -339,8 +339,8 @@ class UnmarshalServiceFrameChouetteTest extends AbstractUnmarshalFrameTest {
         CompositeFrame compositeFrame = (CompositeFrame) publicationDeliveryStructure.getDataObjects().getCompositeFrameOrCommonFrame().get(0).getValue();
         ServiceFrame serviceFrame = (ServiceFrame) compositeFrame.getFrames().getCommonFrame().get(0).getValue();
 
-        Line line = (Line) serviceFrame.getLines().getLine_().get(0).getValue();
-        assertEquals("Line One", line.getName().getValue());
+        Line line = (Line) serviceFrame.getLines().getLine_Dummy().get(0).getValue();
+        assertEquals("Line One", getStringValue(line.getName()));
         assertEquals("PRIV001", line.getPrivateCode().getValue());
 
         PresentationStructure presentation = line.getPresentation();
@@ -391,18 +391,18 @@ class UnmarshalServiceFrameChouetteTest extends AbstractUnmarshalFrameTest {
         ServiceFrame serviceFrame = (ServiceFrame) compositeFrame.getFrames().getCommonFrame().get(0).getValue();
 
         Notice notice = serviceFrame.getNotices().getNotice().get(0);
-        assertEquals("Stopper ikke alle holdeplasser", notice.getText().getValue());
+        assertEquals("Stopper ikke alle holdeplasser", getStringValue(notice.getText()));
         assertEquals("no", notice.getText().getLang());
 
         assertNotNull(notice.getAlternativeTexts());
         assertEquals(2, notice.getAlternativeTexts().getAlternativeText().size());
 
         AlternativeText alt1 = notice.getAlternativeTexts().getAlternativeText().get(0);
-        assertEquals("Does not stop at all stops", alt1.getText().getValue());
+        assertEquals("Does not stop at all stops", getStringValue(alt1.getText()));
         assertEquals("en", alt1.getText().getLang());
 
         AlternativeText alt2 = notice.getAlternativeTexts().getAlternativeText().get(1);
-        assertEquals("Stannar inte vid alla hallplatser", alt2.getText().getValue());
+        assertEquals("Stannar inte vid alla hallplatser", getStringValue(alt2.getText()));
         assertEquals("sv", alt2.getText().getLang());
     }
 

--- a/src/test/java/org/rutebanken/netex/model/UnmarshalServiceFrameExtendedTest.java
+++ b/src/test/java/org/rutebanken/netex/model/UnmarshalServiceFrameExtendedTest.java
@@ -61,7 +61,7 @@ class UnmarshalServiceFrameExtendedTest extends AbstractUnmarshalFrameTest {
         ServiceFrame serviceFrame = (ServiceFrame) compositeFrame.getFrames().getCommonFrame().get(0).getValue();
         Network network = serviceFrame.getNetwork();
         assertNotNull(network);
-        assertEquals("Test Network", network.getName().getValue());
+        assertEquals("Test Network", getStringValue(network.getName()));
         assertEquals("TST:Authority:1", network.getTransportOrganisationRef().getValue().getRef());
     }
 
@@ -107,13 +107,13 @@ class UnmarshalServiceFrameExtendedTest extends AbstractUnmarshalFrameTest {
         ServiceFrame serviceFrame = (ServiceFrame) compositeFrame.getFrames().getCommonFrame().get(0).getValue();
 
         DestinationDisplay destinationDisplay = serviceFrame.getDestinationDisplays().getDestinationDisplay().get(0);
-        assertEquals("Oslo S", destinationDisplay.getFrontText().getValue());
+        assertEquals("Oslo S", getStringValue(destinationDisplay.getFrontText()));
 
         assertEquals(2, serviceFrame.getScheduledStopPoints().getScheduledStopPoint().size());
         ScheduledStopPoint ssp1 = serviceFrame.getScheduledStopPoints().getScheduledStopPoint().get(0);
-        assertEquals("Jernbanetorget", ssp1.getName().getValue());
+        assertEquals("Jernbanetorget", getStringValue(ssp1.getName()));
         ScheduledStopPoint ssp2 = serviceFrame.getScheduledStopPoints().getScheduledStopPoint().get(1);
-        assertEquals("Majorstuen", ssp2.getName().getValue());
+        assertEquals("Majorstuen", getStringValue(ssp2.getName()));
     }
 
     @Test
@@ -202,13 +202,13 @@ class UnmarshalServiceFrameExtendedTest extends AbstractUnmarshalFrameTest {
 
         ServiceFrame serviceFrame = (ServiceFrame) compositeFrame.getFrames().getCommonFrame().get(0).getValue();
 
-        FlexibleLine flexibleLine = (FlexibleLine) serviceFrame.getLines().getLine_().get(0).getValue();
-        assertEquals("Flex Route 1", flexibleLine.getName().getValue());
-        assertEquals(AllVehicleModesOfTransportEnumeration.BUS, flexibleLine.getTransportMode());
+        FlexibleLine flexibleLine = (FlexibleLine) serviceFrame.getLines().getLine_Dummy().get(0).getValue();
+        assertEquals("Flex Route 1", getStringValue(flexibleLine.getName()));
+        assertEquals(AllPublicTransportModesEnumeration.BUS, flexibleLine.getTransportMode());
         assertEquals(FlexibleLineTypeEnumeration.FLEXIBLE_AREAS_ONLY, flexibleLine.getFlexibleLineType());
 
         GroupOfLines groupOfLines = serviceFrame.getGroupsOfLines().getGroupOfLines().get(0);
-        assertEquals("Line Group A", groupOfLines.getName().getValue());
+        assertEquals("Line Group A", getStringValue(groupOfLines.getName()));
         assertEquals(2, groupOfLines.getMembers().getLineRef().size());
         assertEquals("TST:Line:1", groupOfLines.getMembers().getLineRef().get(0).getValue().getRef());
         assertEquals("TST:Line:2", groupOfLines.getMembers().getLineRef().get(1).getValue().getRef());
@@ -256,10 +256,10 @@ class UnmarshalServiceFrameExtendedTest extends AbstractUnmarshalFrameTest {
 
         assertEquals(1, serviceFrame.getNotices().getNotice().size());
         Notice notice = serviceFrame.getNotices().getNotice().get(0);
-        assertEquals("Does not stop at all stops", notice.getText().getValue());
-        assertEquals("A", notice.getPublicCode());
+        assertEquals("Does not stop at all stops", getStringValue(notice.getText()));
+        assertEquals("A", notice.getPublicCode().getValue());
 
-        NoticeAssignment noticeAssignment = (NoticeAssignment) serviceFrame.getNoticeAssignments().getNoticeAssignment_().get(0).getValue();
+        NoticeAssignment noticeAssignment = (NoticeAssignment) serviceFrame.getNoticeAssignments().getNoticeAssignment_Dummy().get(0).getValue();
         assertEquals("TST:Notice:1", noticeAssignment.getNoticeRef().getRef());
         assertEquals("TST:ServiceJourney:1", noticeAssignment.getNoticedObjectRef().getRef());
     }

--- a/src/test/java/org/rutebanken/netex/model/UnmarshalServiceFrameTest.java
+++ b/src/test/java/org/rutebanken/netex/model/UnmarshalServiceFrameTest.java
@@ -146,21 +146,21 @@ class UnmarshalServiceFrameTest extends AbstractUnmarshalFrameTest{
         CompositeFrame compositeFrame = (CompositeFrame) publicationDeliveryStructure.getDataObjects().getCompositeFrameOrCommonFrame().get(0).getValue();
 
         ServiceFrame serviceFrame = (ServiceFrame) compositeFrame.getFrames().getCommonFrame().get(0).getValue();
-        Line line = (Line) serviceFrame.getLines().getLine_().get(0).getValue();
-        assertEquals("Narvik-Riksgränsen (Sverige)", line.getName().getValue());
-        assertEquals("F8", line.getPublicCode());
+        Line line = (Line) serviceFrame.getLines().getLine_Dummy().get(0).getValue();
+        assertEquals("Narvik-Riksgränsen (Sverige)", getStringValue(line.getName()));
+        assertEquals("F8", line.getPublicCode().getValue());
         assertEquals("F8", line.getPrivateCode().getValue());
         assertEquals("rail", line.getTransportMode().value());
 
-        Route route = (Route) serviceFrame.getRoutes().getRoute_().get(0).getValue();
-        assertEquals("Riksgränsen-Narvik  Ofotbanen", route.getName().getValue());
-        assertEquals("KJ-NK", route.getShortName().getValue());
+        Route route = (Route) serviceFrame.getRoutes().getRoute_Dummy().get(0).getValue();
+        assertEquals("Riksgränsen-Narvik  Ofotbanen", getStringValue(route.getName()));
+        assertEquals("KJ-NK", getStringValue(route.getShortName()));
 
         PointOnRoute pointOnRoute = route.getPointsInSequence().getPointOnRoute().get(0);
         assertEquals("VYG:RoutePoint:KJ", pointOnRoute.getPointRef().getValue().getRef());
 
-        JourneyPattern journeyPattern = (JourneyPattern) serviceFrame.getJourneyPatterns().getJourneyPattern_OrJourneyPatternView().get(0).getValue();
-        assertEquals("KMB-NK", journeyPattern.getName().getValue());
+        JourneyPattern journeyPattern = (JourneyPattern) serviceFrame.getJourneyPatterns().getJourneyPattern_Dummy().get(0).getValue();
+        assertEquals("KMB-NK", getStringValue(journeyPattern.getName()));
         assertEquals("VYG:Route:F8-R", journeyPattern.getRouteRef().getRef());
 
         StopPointInJourneyPattern stopPointInJourneyPattern = (StopPointInJourneyPattern) journeyPattern.getPointsInSequence().getPointInJourneyPatternOrStopPointInJourneyPatternOrTimingPointInJourneyPattern().get(0);

--- a/src/test/java/org/rutebanken/netex/model/UnmarshalSiteFrameChouetteTest.java
+++ b/src/test/java/org/rutebanken/netex/model/UnmarshalSiteFrameChouetteTest.java
@@ -57,11 +57,11 @@ class UnmarshalSiteFrameChouetteTest extends AbstractUnmarshalFrameTest {
         PublicationDeliveryStructure publicationDeliveryStructure = jaxbElement.getValue();
         SiteFrame siteFrame = (SiteFrame) publicationDeliveryStructure.getDataObjects().getCompositeFrameOrCommonFrame().get(0).getValue();
 
-        StopPlace stopPlace = (StopPlace) siteFrame.getStopPlaces().getStopPlace_().get(0).getValue();
-        assertEquals("Oslo S", stopPlace.getName().getValue());
-        assertEquals("Main train station", stopPlace.getDescription().getValue());
-        assertEquals("Central Station Clock Tower", stopPlace.getLandmark().getValue());
-        assertEquals(AllVehicleModesOfTransportEnumeration.RAIL, stopPlace.getTransportMode());
+        StopPlace stopPlace = siteFrame.getStopPlaces().getStopPlace().get(0);
+        assertEquals("Oslo S", getStringValue(stopPlace.getName()));
+        assertEquals("Main train station", getStringValue(stopPlace.getDescription()));
+        assertEquals("Central Station Clock Tower", getStringValue(stopPlace.getLandmark()));
+        assertEquals(AllPublicTransportModesEnumeration.RAIL, stopPlace.getTransportMode());
         assertEquals("OSL001", stopPlace.getPrivateCode().getValue());
     }
 }

--- a/src/test/java/org/rutebanken/netex/model/UnmarshalSiteFrameExtendedTest.java
+++ b/src/test/java/org/rutebanken/netex/model/UnmarshalSiteFrameExtendedTest.java
@@ -65,8 +65,8 @@ class UnmarshalSiteFrameExtendedTest extends AbstractUnmarshalFrameTest {
         PublicationDeliveryStructure publicationDeliveryStructure = jaxbElement.getValue();
         SiteFrame siteFrame = (SiteFrame) publicationDeliveryStructure.getDataObjects().getCompositeFrameOrCommonFrame().get(0).getValue();
 
-        StopPlace stopPlace = (StopPlace) siteFrame.getStopPlaces().getStopPlace_().get(0).getValue();
-        assertEquals("Accessible Stop", stopPlace.getName().getValue());
+        StopPlace stopPlace = siteFrame.getStopPlaces().getStopPlace().get(0);
+        assertEquals("Accessible Stop", getStringValue(stopPlace.getName()));
 
         AccessibilityAssessment assessment = stopPlace.getAccessibilityAssessment();
         assertNotNull(assessment);
@@ -106,8 +106,8 @@ class UnmarshalSiteFrameExtendedTest extends AbstractUnmarshalFrameTest {
         SiteFrame siteFrame = (SiteFrame) publicationDeliveryStructure.getDataObjects().getCompositeFrameOrCommonFrame().get(0).getValue();
 
         FlexibleStopPlace flexibleStopPlace = siteFrame.getFlexibleStopPlaces().getFlexibleStopPlace().get(0);
-        assertEquals("Flexible Area North", flexibleStopPlace.getName().getValue());
-        assertEquals(AllVehicleModesOfTransportEnumeration.BUS, flexibleStopPlace.getTransportMode());
+        assertEquals("Flexible Area North", getStringValue(flexibleStopPlace.getName()));
+        assertEquals(AllPublicTransportModesEnumeration.BUS, flexibleStopPlace.getTransportMode());
     }
 
     @Test
@@ -139,8 +139,8 @@ class UnmarshalSiteFrameExtendedTest extends AbstractUnmarshalFrameTest {
         PublicationDeliveryStructure publicationDeliveryStructure = jaxbElement.getValue();
         SiteFrame siteFrame = (SiteFrame) publicationDeliveryStructure.getDataObjects().getCompositeFrameOrCommonFrame().get(0).getValue();
 
-        Parking parking = siteFrame.getParkings().getParking().get(0);
-        assertEquals("Central Parking", parking.getName().getValue());
+        Parking parking = (Parking) siteFrame.getParkings().getParking_Dummy().get(0).getValue();
+        assertEquals("Central Parking", getStringValue(parking.getName()));
         assertEquals(ParkingTypeEnumeration.PARK_AND_RIDE, parking.getParkingType());
         assertEquals(BigInteger.valueOf(250), parking.getTotalCapacity());
     }

--- a/src/test/java/org/rutebanken/netex/model/UnmarshalSiteFrameTest.java
+++ b/src/test/java/org/rutebanken/netex/model/UnmarshalSiteFrameTest.java
@@ -157,19 +157,19 @@ class UnmarshalSiteFrameTest extends AbstractUnmarshalFrameTest {
         PublicationDeliveryStructure publicationDeliveryStructure = jaxbElement.getValue();
         SiteFrame siteFrame = (SiteFrame) publicationDeliveryStructure.getDataObjects().getCompositeFrameOrCommonFrame().get(0).getValue();
 
-        StopPlace stopPlace = (StopPlace) siteFrame.getStopPlaces().getStopPlace_().get(0).getValue();
-        assertEquals("Krokstien", stopPlace.getName().getValue());
-        assertEquals(AllVehicleModesOfTransportEnumeration.BUS, stopPlace.getTransportMode());
+        StopPlace stopPlace = siteFrame.getStopPlaces().getStopPlace().get(0);
+        assertEquals("Krokstien", getStringValue(stopPlace.getName()));
+        assertEquals(AllPublicTransportModesEnumeration.BUS, stopPlace.getTransportMode());
         assertEquals(StopTypeEnumeration.ONSTREET_BUS, stopPlace.getStopPlaceType());
-        assertEquals("BRA:TariffZone:311", stopPlace.getTariffZones().getTariffZoneRef_().get(0).getValue().getRef());
+        assertEquals("BRA:TariffZone:311", stopPlace.getTariffZones().getTariffZoneRef_Dummy().get(0).getValue().getRef());
 
         Quay quay = (Quay) stopPlace.getQuays().getQuayRefOrQuay().get(0).getValue();
         assertEquals(BigDecimal.valueOf(59.910579), quay.getCentroid().getLocation().getLatitude());
         TariffZone tariffZone = (TariffZone) siteFrame.getTariffZones().getTariffZone().get(0).getValue();
-        assertEquals("1", tariffZone.getName().getValue());
+        assertEquals("1", getStringValue(tariffZone.getName()));
 
         GroupOfStopPlaces groupOfStopPlaces = siteFrame.getGroupsOfStopPlaces().getGroupOfStopPlaces().get(0);
-        assertEquals("Lillehammer", groupOfStopPlaces.getName().getValue());
+        assertEquals("Lillehammer", getStringValue(groupOfStopPlaces.getName()));
         assertEquals("NSR:StopPlace:420", groupOfStopPlaces.getMembers().getStopPlaceRef().get(0).getValue().getRef());
     }
 
@@ -211,7 +211,7 @@ class UnmarshalSiteFrameTest extends AbstractUnmarshalFrameTest {
         SiteFrame siteFrame = (SiteFrame) publicationDeliveryStructure.getDataObjects().getCompositeFrameOrCommonFrame().get(0).getValue();
 
         TopographicPlace topographicPlace = siteFrame.getTopographicPlaces().getTopographicPlace().get(0);
-        assertEquals("Oslo", topographicPlace.getDescriptor().getName().getValue());
+        assertEquals("Oslo", getStringValue(topographicPlace.getDescriptor().getName()));
         assertEquals(TopographicPlaceTypeEnumeration.MUNICIPALITY, topographicPlace.getTopographicPlaceType());
         assertNotNull(topographicPlace.getPolygon());
     }

--- a/src/test/java/org/rutebanken/netex/model/UnmarshalTimetableFrameChouetteTest.java
+++ b/src/test/java/org/rutebanken/netex/model/UnmarshalTimetableFrameChouetteTest.java
@@ -77,8 +77,8 @@ class UnmarshalTimetableFrameChouetteTest extends AbstractUnmarshalFrameTest {
 
         DeadRun deadRun = (DeadRun) timetableFrame.getVehicleJourneys()
                 .getVehicleJourneyOrDatedVehicleJourneyOrNormalDatedVehicleJourney().get(0);
-        assertEquals("Dead Run to Depot", deadRun.getName().getValue());
-        assertEquals(AllVehicleModesOfTransportEnumeration.BUS, deadRun.getTransportMode());
+        assertEquals("Dead Run to Depot", getStringValue(deadRun.getName()));
+        assertEquals(AllPublicTransportModesEnumeration.BUS, deadRun.getTransportMode());
 
         assertNotNull(deadRun.getDayTypes());
         assertEquals("TST:DayType:Weekday", deadRun.getDayTypes().getDayTypeRef().get(0).getValue().getRef());
@@ -151,7 +151,7 @@ class UnmarshalTimetableFrameChouetteTest extends AbstractUnmarshalFrameTest {
         assertEquals(PurchaseMomentEnumeration.BEFORE_BOARDING, fsp.getBuyWhen().get(0));
         assertEquals(PurchaseMomentEnumeration.ON_BOARDING, fsp.getBuyWhen().get(1));
 
-        assertEquals("Advanced booking required", fsp.getBookingNote().getValue());
+        assertEquals("Advanced booking required", getStringValue(fsp.getBookingNote()));
         assertEquals("+47 99998888", fsp.getBookingContact().getPhone());
     }
 }

--- a/src/test/java/org/rutebanken/netex/model/UnmarshalTimetableFrameExtendedTest.java
+++ b/src/test/java/org/rutebanken/netex/model/UnmarshalTimetableFrameExtendedTest.java
@@ -124,7 +124,7 @@ class UnmarshalTimetableFrameExtendedTest extends AbstractUnmarshalFrameTest {
 
         ServiceJourney serviceJourney = (ServiceJourney) timetableFrame.getVehicleJourneys()
                 .getVehicleJourneyOrDatedVehicleJourneyOrNormalDatedVehicleJourney().get(0);
-        assertEquals("Flex Service", serviceJourney.getName().getValue());
+        assertEquals("Flex Service", getStringValue(serviceJourney.getName()));
 
         FlexibleServiceProperties flexProps = serviceJourney.getFlexibleServiceProperties();
         assertEquals(BookingAccessEnumeration.PUBLIC, flexProps.getBookingAccess());

--- a/src/test/java/org/rutebanken/netex/model/UnmarshalTimetableFrameTest.java
+++ b/src/test/java/org/rutebanken/netex/model/UnmarshalTimetableFrameTest.java
@@ -120,7 +120,7 @@ class UnmarshalTimetableFrameTest extends AbstractUnmarshalFrameTest {
 
         TimetableFrame timetableFrame = (TimetableFrame) compositeFrame.getFrames().getCommonFrame().get(0).getValue();
         ServiceJourney serviceJourney = (ServiceJourney) timetableFrame.getVehicleJourneys().getVehicleJourneyOrDatedVehicleJourneyOrNormalDatedVehicleJourney().get(0);
-        assertEquals("96", serviceJourney.getName().getValue());
+        assertEquals("96", getStringValue(serviceJourney.getName()));
         assertEquals("96", serviceJourney.getPrivateCode().getValue());
         assertEquals("rail", serviceJourney.getTransportMode().value());
 

--- a/src/test/java/org/rutebanken/netex/model/UnmarshalTransportSubModeTest.java
+++ b/src/test/java/org/rutebanken/netex/model/UnmarshalTransportSubModeTest.java
@@ -76,28 +76,28 @@ class UnmarshalTransportSubModeTest extends AbstractUnmarshalFrameTest {
         PublicationDeliveryStructure publicationDeliveryStructure = jaxbElement.getValue();
         SiteFrame siteFrame = (SiteFrame) publicationDeliveryStructure.getDataObjects().getCompositeFrameOrCommonFrame().get(0).getValue();
 
-        StopPlace busStop = (StopPlace) siteFrame.getStopPlaces().getStopPlace_().get(0).getValue();
-        assertEquals(AllVehicleModesOfTransportEnumeration.BUS, busStop.getTransportMode());
+        StopPlace busStop = siteFrame.getStopPlaces().getStopPlace().get(0);
+        assertEquals(AllPublicTransportModesEnumeration.BUS, busStop.getTransportMode());
         assertEquals(BusSubmodeEnumeration.EXPRESS_BUS, busStop.getBusSubmode());
         assertEquals("expressBus", busStop.getBusSubmode().value());
 
-        StopPlace railStop = (StopPlace) siteFrame.getStopPlaces().getStopPlace_().get(1).getValue();
-        assertEquals(AllVehicleModesOfTransportEnumeration.RAIL, railStop.getTransportMode());
+        StopPlace railStop = siteFrame.getStopPlaces().getStopPlace().get(1);
+        assertEquals(AllPublicTransportModesEnumeration.RAIL, railStop.getTransportMode());
         assertEquals(RailSubmodeEnumeration.REGIONAL_RAIL, railStop.getRailSubmode());
         assertEquals("regionalRail", railStop.getRailSubmode().value());
 
-        StopPlace waterStop = (StopPlace) siteFrame.getStopPlaces().getStopPlace_().get(2).getValue();
-        assertEquals(AllVehicleModesOfTransportEnumeration.WATER, waterStop.getTransportMode());
+        StopPlace waterStop = siteFrame.getStopPlaces().getStopPlace().get(2);
+        assertEquals(AllPublicTransportModesEnumeration.WATER, waterStop.getTransportMode());
         assertEquals(WaterSubmodeEnumeration.LOCAL_CAR_FERRY, waterStop.getWaterSubmode());
         assertEquals("localCarFerry", waterStop.getWaterSubmode().value());
 
-        StopPlace tramStop = (StopPlace) siteFrame.getStopPlaces().getStopPlace_().get(3).getValue();
-        assertEquals(AllVehicleModesOfTransportEnumeration.TRAM, tramStop.getTransportMode());
+        StopPlace tramStop = siteFrame.getStopPlaces().getStopPlace().get(3);
+        assertEquals(AllPublicTransportModesEnumeration.TRAM, tramStop.getTransportMode());
         assertEquals(TramSubmodeEnumeration.CITY_TRAM, tramStop.getTramSubmode());
         assertEquals("cityTram", tramStop.getTramSubmode().value());
 
-        StopPlace metroStop = (StopPlace) siteFrame.getStopPlaces().getStopPlace_().get(4).getValue();
-        assertEquals(AllVehicleModesOfTransportEnumeration.METRO, metroStop.getTransportMode());
+        StopPlace metroStop = siteFrame.getStopPlaces().getStopPlace().get(4);
+        assertEquals(AllPublicTransportModesEnumeration.METRO, metroStop.getTransportMode());
         assertEquals(MetroSubmodeEnumeration.METRO, metroStop.getMetroSubmode());
         assertEquals("metro", metroStop.getMetroSubmode().value());
     }
@@ -154,21 +154,21 @@ class UnmarshalTransportSubModeTest extends AbstractUnmarshalFrameTest {
 
         ServiceJourney busSj = (ServiceJourney) timetableFrame.getVehicleJourneys()
                 .getVehicleJourneyOrDatedVehicleJourneyOrNormalDatedVehicleJourney().get(0);
-        assertEquals(AllVehicleModesOfTransportEnumeration.BUS, busSj.getTransportMode());
+        assertEquals(AllPublicTransportModesEnumeration.BUS, busSj.getTransportMode());
         assertNotNull(busSj.getTransportSubmode());
         assertEquals(BusSubmodeEnumeration.EXPRESS_BUS, busSj.getTransportSubmode().getBusSubmode());
         assertEquals("expressBus", busSj.getTransportSubmode().getBusSubmode().value());
 
         ServiceJourney railSj = (ServiceJourney) timetableFrame.getVehicleJourneys()
                 .getVehicleJourneyOrDatedVehicleJourneyOrNormalDatedVehicleJourney().get(1);
-        assertEquals(AllVehicleModesOfTransportEnumeration.RAIL, railSj.getTransportMode());
+        assertEquals(AllPublicTransportModesEnumeration.RAIL, railSj.getTransportMode());
         assertNotNull(railSj.getTransportSubmode());
         assertEquals(RailSubmodeEnumeration.REGIONAL_RAIL, railSj.getTransportSubmode().getRailSubmode());
         assertEquals("regionalRail", railSj.getTransportSubmode().getRailSubmode().value());
 
         ServiceJourney waterSj = (ServiceJourney) timetableFrame.getVehicleJourneys()
                 .getVehicleJourneyOrDatedVehicleJourneyOrNormalDatedVehicleJourney().get(2);
-        assertEquals(AllVehicleModesOfTransportEnumeration.WATER, waterSj.getTransportMode());
+        assertEquals(AllPublicTransportModesEnumeration.WATER, waterSj.getTransportMode());
         assertNotNull(waterSj.getTransportSubmode());
         assertEquals(WaterSubmodeEnumeration.LOCAL_PASSENGER_FERRY, waterSj.getTransportSubmode().getWaterSubmode());
         assertEquals("localPassengerFerry", waterSj.getTransportSubmode().getWaterSubmode().value());
@@ -212,8 +212,8 @@ class UnmarshalTransportSubModeTest extends AbstractUnmarshalFrameTest {
         CompositeFrame compositeFrame = (CompositeFrame) publicationDeliveryStructure.getDataObjects().getCompositeFrameOrCommonFrame().get(0).getValue();
         ServiceFrame serviceFrame = (ServiceFrame) compositeFrame.getFrames().getCommonFrame().get(0).getValue();
 
-        Route route = (Route) serviceFrame.getRoutes().getRoute_().get(0).getValue();
-        assertEquals("Main Route", route.getName().getValue());
+        Route route = (Route) serviceFrame.getRoutes().getRoute_Dummy().get(0).getValue();
+        assertEquals("Main Route", getStringValue(route.getName()));
         assertNotNull(route.getLineRef());
         assertEquals("TST:Line:100", route.getLineRef().getValue().getRef());
     }
@@ -262,23 +262,23 @@ class UnmarshalTransportSubModeTest extends AbstractUnmarshalFrameTest {
         PublicationDeliveryStructure publicationDeliveryStructure = jaxbElement.getValue();
         SiteFrame siteFrame = (SiteFrame) publicationDeliveryStructure.getDataObjects().getCompositeFrameOrCommonFrame().get(0).getValue();
 
-        StopPlace coachStop = (StopPlace) siteFrame.getStopPlaces().getStopPlace_().get(0).getValue();
-        assertEquals(AllVehicleModesOfTransportEnumeration.COACH, coachStop.getTransportMode());
+        StopPlace coachStop = siteFrame.getStopPlaces().getStopPlace().get(0);
+        assertEquals(AllPublicTransportModesEnumeration.COACH, coachStop.getTransportMode());
         assertEquals(CoachSubmodeEnumeration.INTERNATIONAL_COACH, coachStop.getCoachSubmode());
         assertEquals("internationalCoach", coachStop.getCoachSubmode().value());
 
-        StopPlace funicularStop = (StopPlace) siteFrame.getStopPlaces().getStopPlace_().get(1).getValue();
-        assertEquals(AllVehicleModesOfTransportEnumeration.FUNICULAR, funicularStop.getTransportMode());
+        StopPlace funicularStop = siteFrame.getStopPlaces().getStopPlace().get(1);
+        assertEquals(AllPublicTransportModesEnumeration.FUNICULAR, funicularStop.getTransportMode());
         assertEquals(FunicularSubmodeEnumeration.FUNICULAR, funicularStop.getFunicularSubmode());
         assertEquals("funicular", funicularStop.getFunicularSubmode().value());
 
-        StopPlace telecabinStop = (StopPlace) siteFrame.getStopPlaces().getStopPlace_().get(2).getValue();
-        assertEquals(AllVehicleModesOfTransportEnumeration.CABLEWAY, telecabinStop.getTransportMode());
+        StopPlace telecabinStop = siteFrame.getStopPlaces().getStopPlace().get(2);
+        assertEquals(AllPublicTransportModesEnumeration.CABLEWAY, telecabinStop.getTransportMode());
         assertEquals(TelecabinSubmodeEnumeration.TELECABIN, telecabinStop.getTelecabinSubmode());
         assertEquals("telecabin", telecabinStop.getTelecabinSubmode().value());
 
-        StopPlace airStop = (StopPlace) siteFrame.getStopPlaces().getStopPlace_().get(3).getValue();
-        assertEquals(AllVehicleModesOfTransportEnumeration.AIR, airStop.getTransportMode());
+        StopPlace airStop = siteFrame.getStopPlaces().getStopPlace().get(3);
+        assertEquals(AllPublicTransportModesEnumeration.AIR, airStop.getTransportMode());
         assertEquals(AirSubmodeEnumeration.DOMESTIC_FLIGHT, airStop.getAirSubmode());
         assertEquals("domesticFlight", airStop.getAirSubmode().value());
     }

--- a/src/test/java/org/rutebanken/netex/model/UnmarshalVehicleScheduleFrameChouetteTest.java
+++ b/src/test/java/org/rutebanken/netex/model/UnmarshalVehicleScheduleFrameChouetteTest.java
@@ -82,8 +82,8 @@ class UnmarshalVehicleScheduleFrameChouetteTest extends AbstractUnmarshalFrameTe
         assertEquals(1, vsFrame.getBlocks().getBlockOrCompoundBlockOrTrainBlock().size());
 
         Block block = (Block) vsFrame.getBlocks().getBlockOrCompoundBlockOrTrainBlock().get(0);
-        assertEquals("Morning Block", block.getName().getValue());
-        assertEquals("First block of the day", block.getDescription().getValue());
+        assertEquals("Morning Block", getStringValue(block.getName()));
+        assertEquals("First block of the day", getStringValue(block.getDescription()));
         assertEquals("BLK001", block.getPrivateCode().getValue());
         assertEquals(LocalTime.of(5, 30), block.getStartTime());
         assertEquals(LocalTime.of(12, 0), block.getEndTime());


### PR DESCRIPTION
## Summary
Upgrade the NeTEx schema from version 1.16 to 2.0.

## Changes

### JAXB Bindings (bindings.xjb)
- Updated XPath for `TariffZone_` → `TariffZone_Dummy` (renamed in 2.0)
- Removed obsolete `HeadwayJourneyGroupGroup/Description` binding (element removed in 2.0)
- Added bindings to resolve ObjectFactory name collisions for `bookingArrangements` vs `BookingArrangements` in multiple XSD files

### Test Updates
Updated all tests for NeTEx 2.0 API changes:
- `MultilingualString` now uses mixed content model (`withContent()`/`getContent()` instead of `withValue()`/`getValue()`)
- Collection getters renamed with `_Dummy` suffix (e.g., `getLine_()` → `getLine_Dummy()`)
- `StopPlacesInFrame_RelStructure` now returns `List<StopPlace>` directly instead of wrapped JAXBElements
- `AllVehicleModesOfTransportEnumeration` renamed to `AllPublicTransportModesEnumeration`
- `PublicCode` and `PrivateCode` now use structure types with `.getValue()` method
- Replaced removed `DatedCall` class tests with `AvailabilityCondition` tests
- Added helper method `getStringValue(MultilingualString)` for extracting text from mixed content

## Testing
All 18 tests pass with `mvn clean install -Dexec.skip=true`