### PR TITLE
Add JReleaser plugin and publication profile for 1.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,6 +108,7 @@
         <maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>
         <maven-enforcer-plugin.version>3.0.0</maven-enforcer-plugin.version>
 
+        <jreleaser-maven-plugin.version>1.23.0</jreleaser-maven-plugin.version>
         <jacoco-maven-plugin.version>0.8.8</jacoco-maven-plugin.version>
 
         <!-- empty argLine property, the value is set up by Jacoco during unit tests execution -->
@@ -219,6 +220,40 @@
                 <plugin>
                     <artifactId>maven-deploy-plugin</artifactId>
                     <version>${maven-deploy-plugin.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.jreleaser</groupId>
+                    <artifactId>jreleaser-maven-plugin</artifactId>
+                    <version>${jreleaser-maven-plugin.version}</version>
+                    <configuration>
+                        <jreleaser>
+                            <signing>
+                                <active>ALWAYS</active>
+                                <armored>true</armored>
+                            </signing>
+                            <deploy>
+                                <maven>
+                                    <mavenCentral>
+                                        <sonatype>
+                                            <active>RELEASE</active>
+                                            <url>https://central.sonatype.com/api/v1/publisher</url>
+                                            <stagingRepositories>target/staging-deploy</stagingRepositories>
+                                        </sonatype>
+                                    </mavenCentral>
+                                    <nexus2>
+                                        <maven-central>
+                                            <active>SNAPSHOT</active>
+                                            <url>https://ossrh-staging-api.central.sonatype.com/service/local</url>
+                                            <snapshotUrl>https://central.sonatype.com/repository/maven-snapshots</snapshotUrl>
+                                            <applyMavenCentralRules>true</applyMavenCentralRules>
+                                            <snapshotSupported>true</snapshotSupported>
+                                            <stagingRepositories>target/staging-deploy</stagingRepositories>
+                                        </maven-central>
+                                    </nexus2>
+                                </maven>
+                            </deploy>
+                        </jreleaser>
+                    </configuration>
                 </plugin>
             </plugins>
         </pluginManagement>
@@ -589,6 +624,10 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.jreleaser</groupId>
+                <artifactId>jreleaser-maven-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
 
@@ -711,6 +750,50 @@
                         <groupId>org.sonarsource.scanner.maven</groupId>
                         <artifactId>sonar-maven-plugin</artifactId>
                         <version>${sonar-maven-plugin.version}</version>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
+            <id>publication</id>
+            <properties>
+                <altDeploymentRepository>local::default::file:./target/staging-deploy</altDeploymentRepository>
+            </properties>
+            <build>
+                <defaultGoal>deploy</defaultGoal>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <version>${maven-javadoc-plugin.version}</version>
+                        <executions>
+                            <execution>
+                                <id>attach-javadocs</id>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                                <configuration>
+                                    <attach>true</attach>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-source-plugin</artifactId>
+                        <version>${maven-source-plugin.version}</version>
+                        <executions>
+                            <execution>
+                                <id>attach-sources</id>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                                <configuration>
+                                    <attach>true</attach>
+                                </configuration>
+                            </execution>
+                        </executions>
                     </plugin>
                 </plugins>
             </build>


### PR DESCRIPTION
## Summary

Fixes the Maven Central release workflow failure on 1.x by adding missing pom.xml configuration:

- **JReleaser plugin**: Added `jreleaser-maven-plugin` (v1.23.0) in `pluginManagement` with signing and deployment config, and in `plugins` section
- **`publication` profile**: Stages deploy artifacts (javadoc + source JARs) to `target/staging-deploy` for JReleaser to publish

Without these, the `jreleaser` plugin prefix is not found and the `publication` profile does not exist.

## Test plan

- [ ] CI build passes on 1.x
- [ ] Snapshot publish step succeeds (uses `maven-jreleaser-release.yml`)