### PR TITLE
Deduplicate `LocalTime`

### DIFF
--- a/src/main/java/org/rutebanken/util/LocalTimeISO8601XmlAdapter.java
+++ b/src/main/java/org/rutebanken/util/LocalTimeISO8601XmlAdapter.java
@@ -33,6 +33,13 @@ public class LocalTimeISO8601XmlAdapter extends XmlAdapter<String, LocalTime> {
 //
 	.parseDefaulting(ChronoField.OFFSET_SECONDS,OffsetDateTime.now().getLong(ChronoField.OFFSET_SECONDS) ).toFormatter();
 
+	/**
+	 * We store a cache of parsed LocalTime instances to avoid wasting memory in immutable value
+	 * objects that strictly identical and interchangeable.
+	 * Since there is a limited number of seconds in a single day, this cannot grow unbounded.
+	 * If input data differs by milliseconds or even nanoseconds, this might cause problems. It
+	 * is, however, very unlikely to happen in the context of NeTEx.
+	 */
 	private final HashMap<LocalTime, LocalTime> cache = new HashMap<>();
 
 	@Override

--- a/src/main/java/org/rutebanken/util/LocalTimeISO8601XmlAdapter.java
+++ b/src/main/java/org/rutebanken/util/LocalTimeISO8601XmlAdapter.java
@@ -33,11 +33,12 @@ public class LocalTimeISO8601XmlAdapter extends XmlAdapter<String, LocalTime> {
 //
 	.parseDefaulting(ChronoField.OFFSET_SECONDS,OffsetDateTime.now().getLong(ChronoField.OFFSET_SECONDS) ).toFormatter();
 
-	private final HashMap<String, LocalTime> cache = new HashMap<>();
+	private final HashMap<LocalTime, LocalTime> cache = new HashMap<>();
 
 	@Override
-	public LocalTime unmarshal(String inputDate) {
-		return cache.computeIfAbsent(inputDate, key -> LocalTime.parse(key, formatter));
+	public LocalTime unmarshal(String input) {
+		var key = LocalTime.parse(input, formatter);
+		return cache.computeIfAbsent(key, time -> time);
 	}
 
 	@Override

--- a/src/main/java/org/rutebanken/util/LocalTimeISO8601XmlAdapter.java
+++ b/src/main/java/org/rutebanken/util/LocalTimeISO8601XmlAdapter.java
@@ -21,6 +21,7 @@ import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
 import java.time.temporal.ChronoField;
+import java.util.HashMap;
 
 public class LocalTimeISO8601XmlAdapter extends XmlAdapter<String, LocalTime> {
 
@@ -28,14 +29,15 @@ public class LocalTimeISO8601XmlAdapter extends XmlAdapter<String, LocalTime> {
 			.optionalStart().appendFraction(ChronoField.MILLI_OF_SECOND, 0, 3, true).optionalEnd()
 			.optionalStart().appendPattern("XXXXX")
             .optionalEnd()
-			
+
 //
 	.parseDefaulting(ChronoField.OFFSET_SECONDS,OffsetDateTime.now().getLong(ChronoField.OFFSET_SECONDS) ).toFormatter();
 
+	private final HashMap<String, LocalTime> cache = new HashMap<>();
+
 	@Override
 	public LocalTime unmarshal(String inputDate) {
-		return LocalTime.parse(inputDate, formatter);
-
+		return cache.computeIfAbsent(inputDate, key -> LocalTime.parse(key, formatter));
 	}
 
 	@Override

--- a/src/main/java/org/rutebanken/util/LocalTimeISO8601XmlAdapter.java
+++ b/src/main/java/org/rutebanken/util/LocalTimeISO8601XmlAdapter.java
@@ -22,6 +22,7 @@ import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
 import java.time.temporal.ChronoField;
 import java.util.HashMap;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class LocalTimeISO8601XmlAdapter extends XmlAdapter<String, LocalTime> {
 
@@ -36,16 +37,23 @@ public class LocalTimeISO8601XmlAdapter extends XmlAdapter<String, LocalTime> {
 	/**
 	 * We store a cache of parsed LocalTime instances to avoid wasting memory in immutable value
 	 * objects that strictly identical and interchangeable.
-	 * Since there is a limited number of seconds in a single day, this cannot grow unbounded.
-	 * If input data differs by milliseconds or even nanoseconds, this might cause problems. It
-	 * is, however, very unlikely to happen in the context of NeTEx.
+	 *
+	 * We only cache times that are full seconds to avoid increasing the size of the cache unduly,
+	 * since there is a limited number of seconds in a single day.
 	 */
-	private final HashMap<LocalTime, LocalTime> cache = new HashMap<>();
+	private final ConcurrentHashMap<LocalTime, LocalTime> cache = new ConcurrentHashMap<>();
 
 	@Override
 	public LocalTime unmarshal(String input) {
 		var key = LocalTime.parse(input, formatter);
-		return cache.computeIfAbsent(key, time -> time);
+		// only cache if nano is zero
+		if(key.getNano() == 0){
+			return cache.computeIfAbsent(key, time -> time);
+		}
+		// sub-second times are not cached to not increase the size of the cache unduly
+		else {
+			return key;
+		}
 	}
 
 	@Override

--- a/src/test/java/org/rutebanken/util/LocalTimeISO8601XmlAdapterTest.java
+++ b/src/test/java/org/rutebanken/util/LocalTimeISO8601XmlAdapterTest.java
@@ -1,5 +1,7 @@
 package org.rutebanken.util;
 
+import java.util.List;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 
 import java.time.LocalTime;
@@ -96,5 +98,22 @@ public class LocalTimeISO8601XmlAdapterTest {
         LocalTime first = adapter.unmarshal(timeString);
         LocalTime second = adapter.unmarshal(timeString);
         assertSame(first, second, "Same string should return cached instance");
+    }
+
+    @Test
+    public void testCachingIdenticalValue() {
+        var equalInputs = List.of(
+                "12:20:00",
+                "12:20:00+02:00",
+                "12:20:00.000",
+                "12:20:00.000+02:00"
+        );
+
+        var parsed = equalInputs.stream()
+                .map(adapter::unmarshal)
+                .collect(Collectors.toList());
+        var first = parsed.get(0);
+
+        parsed.forEach(time -> assertSame(first, time, "Same time value should return same instance"));
     }
 }

--- a/src/test/java/org/rutebanken/util/LocalTimeISO8601XmlAdapterTest.java
+++ b/src/test/java/org/rutebanken/util/LocalTimeISO8601XmlAdapterTest.java
@@ -1,0 +1,100 @@
+package org.rutebanken.util;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalTime;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class LocalTimeISO8601XmlAdapterTest {
+
+    private final LocalTimeISO8601XmlAdapter adapter = new LocalTimeISO8601XmlAdapter();
+
+    @Test
+    public void testUnmarshalBasicTime() {
+        LocalTime result = adapter.unmarshal("14:30:00");
+        assertEquals(LocalTime.of(14, 30, 0), result);
+    }
+
+    @Test
+    public void testUnmarshalTimeWithMilliseconds() {
+        LocalTime result = adapter.unmarshal("14:30:00.123");
+        assertEquals(LocalTime.of(14, 30, 0, 123_000_000), result);
+    }
+
+    @Test
+    public void testUnmarshalTimeWithOffset() {
+        LocalTime result = adapter.unmarshal("14:30:00+02:00");
+        assertEquals(LocalTime.of(14, 30, 0), result);
+    }
+
+    @Test
+    public void testUnmarshalTimeWithMillisecondsAndOffset() {
+        LocalTime result = adapter.unmarshal("14:30:00.456+01:00");
+        assertEquals(LocalTime.of(14, 30, 0, 456_000_000), result);
+    }
+
+    @Test
+    public void testUnmarshalMidnight() {
+        LocalTime result = adapter.unmarshal("00:00:00");
+        assertEquals(LocalTime.MIDNIGHT, result);
+    }
+
+    @Test
+    public void testUnmarshalNoon() {
+        LocalTime result = adapter.unmarshal("12:00:00");
+        assertEquals(LocalTime.NOON, result);
+    }
+
+    @Test
+    public void testUnmarshalEndOfDay() {
+        LocalTime result = adapter.unmarshal("23:59:59");
+        assertEquals(LocalTime.of(23, 59, 59), result);
+    }
+
+    @Test
+    public void testMarshalBasicTime() {
+        String result = adapter.marshal(LocalTime.of(14, 30, 0));
+        assertEquals("14:30:00", result);
+    }
+
+    @Test
+    public void testMarshalTimeWithNanoseconds() {
+        String result = adapter.marshal(LocalTime.of(14, 30, 0, 123_000_000));
+        assertEquals("14:30:00.123", result);
+    }
+
+    @Test
+    public void testMarshalMidnight() {
+        String result = adapter.marshal(LocalTime.MIDNIGHT);
+        assertEquals("00:00:00", result);
+    }
+
+    @Test
+    public void testMarshalNoon() {
+        String result = adapter.marshal(LocalTime.NOON);
+        assertEquals("12:00:00", result);
+    }
+
+    @Test
+    public void testMarshalNull() {
+        String result = adapter.marshal(null);
+        assertNull(result);
+    }
+
+    @Test
+    public void testRoundTrip() {
+        LocalTime original = LocalTime.of(15, 45, 30, 500_000_000);
+        String marshalled = adapter.marshal(original);
+        LocalTime unmarshalled = adapter.unmarshal(marshalled);
+        assertEquals(original, unmarshalled);
+    }
+
+    @Test
+    public void testCaching() {
+        String timeString = "10:20:30";
+        LocalTime first = adapter.unmarshal(timeString);
+        LocalTime second = adapter.unmarshal(timeString);
+        assertSame(first, second, "Same string should return cached instance");
+    }
+}


### PR DESCRIPTION
This implements deduplication of instances of `LocalTime`.

This is okay, because it's an immutable value object where one instance truly can be replaced with an equal one.

### Improvement

In my current example file this can cut down the number of instances from around 30 million to a few thousand, saving around 800MB of RAM!

cc @vpaturet 

Ref: #284
Ref: https://github.com/noi-techpark/opendatahub-mentor-otp/issues/273

cc @rcavaliere