### PR TITLE
Deduplicate 'any' version attribute

### DIFF
--- a/bindings.xjb
+++ b/bindings.xjb
@@ -59,6 +59,9 @@
 
 	<jxb:bindings
 		schemaLocation="./src/main/resources/xsd/1.16/netex_framework/netex_responsibility/netex_version_support.xsd">
+		<jxb:bindings node="//xsd:simpleType[@name = 'VersionIdType']">
+			<xjc:javaType name="java.lang.String" adapter="org.rutebanken.util.VersionXmlAdapter" />
+		</jxb:bindings>
 		<jxb:bindings node="//xsd:attributeGroup[@name = 'BasicModificationDetailsGroup']/xsd:attribute[@name = 'status']">
 			<jxb:property name="status_BasicModificationDetailsGroup" />
 		</jxb:bindings>

--- a/src/main/java/org/rutebanken/util/VersionXmlAdapter.java
+++ b/src/main/java/org/rutebanken/util/VersionXmlAdapter.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed under the EUPL, Version 1.2 or - as soon they will be approved by
+ * the European Commission - subsequent versions of the EUPL (the "Licence");
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *   https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing permissions and
+ * limitations under the Licence.
+ */
+
+package org.rutebanken.util;
+
+import jakarta.xml.bind.annotation.adapters.XmlAdapter;
+import java.util.HashMap;
+
+public class VersionXmlAdapter extends XmlAdapter<String, String> {
+
+	/**
+	 * EPIP allows the string 'any' as a valid version, so we deduplicate it to conserve memory. In one
+	 * especially bad example this saved 1.7 GB of memory!
+	 */
+	private static final String ANY = "any";
+
+	@Override
+	public String unmarshal(String input) {
+		if(input.equals(ANY)) {
+			return ANY;
+		}
+		else {
+			return input;
+		}
+	}
+
+	@Override
+	public String marshal(String input) {
+		return input;
+	}
+
+}

--- a/src/main/java/org/rutebanken/util/VersionXmlAdapter.java
+++ b/src/main/java/org/rutebanken/util/VersionXmlAdapter.java
@@ -16,7 +16,6 @@
 package org.rutebanken.util;
 
 import jakarta.xml.bind.annotation.adapters.XmlAdapter;
-import java.util.HashMap;
 
 public class VersionXmlAdapter extends XmlAdapter<String, String> {
 
@@ -28,12 +27,7 @@ public class VersionXmlAdapter extends XmlAdapter<String, String> {
 
 	@Override
 	public String unmarshal(String input) {
-		if(input.equals(ANY)) {
-			return ANY;
-		}
-		else {
-			return input;
-		}
+		return ANY.equals(input) ? ANY : input;
 	}
 
 	@Override

--- a/src/test/java/org/rutebanken/util/VersionXmlAdapterTest.java
+++ b/src/test/java/org/rutebanken/util/VersionXmlAdapterTest.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed under the EUPL, Version 1.2 or - as soon they will be approved by
+ * the European Commission - subsequent versions of the EUPL (the "Licence");
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *   https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing permissions and
+ * limitations under the Licence.
+ */
+
+package org.rutebanken.util;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class VersionXmlAdapterTest {
+
+    private final VersionXmlAdapter adapter = new VersionXmlAdapter();
+
+    @Test
+    public void testUnmarshalReturnsValue() {
+        String version = "1.0";
+        String result = adapter.unmarshal(version);
+        assertEquals("1.0", result);
+    }
+
+    @Test
+    public void testUnmarshalDeduplicates() {
+        String version1 = new String("any");
+        String version2 = new String("any");
+
+        // Verify they are different objects initially
+        assertNotSame(version1, version2);
+
+        String result1 = adapter.unmarshal(version1);
+        String result2 = adapter.unmarshal(version2);
+
+        // Verify they return the same cached instance
+        assertSame(result1, result2);
+    }
+
+    @Test
+    public void testMarshalReturnsInput() {
+        String version = "1.07:NO-NeTEx-networktimetable:1.0";
+        String result = adapter.marshal(version);
+        assertEquals(version, result);
+    }
+
+    @Test
+    public void testMarshalNull() {
+        String result = adapter.marshal(null);
+        assertNull(result);
+    }
+}


### PR DESCRIPTION
EPIP allows you to use the version `any` and some feeds us it for _every_ entity.

In my particular example at hand the string `any` is duplicated 72 million times!

<img width="960" height="540" alt="image" src="https://github.com/user-attachments/assets/ae23de83-674d-422b-b9bd-0abbb48dfcf7" />

For this reason, I'm implementing a very simple version de-duplicator which checks for the version "any".

If desired, this could also be a bit more aggressive by, for example, deduplicating purely numeric versions from 0-100.

cc @vpaturet 

Ref: #284
Ref: https://github.com/noi-techpark/opendatahub-mentor-otp/issues/273

cc @rcavaliere