### PR TITLE
Accept sub-millisecond fractional seconds in xs:dateTime

### DIFF
--- a/src/main/java/org/rutebanken/util/LocalDateTimeISO8601XmlAdapter.java
+++ b/src/main/java/org/rutebanken/util/LocalDateTimeISO8601XmlAdapter.java
@@ -25,7 +25,7 @@ import java.time.temporal.ChronoField;
 public class LocalDateTimeISO8601XmlAdapter extends XmlAdapter<String, LocalDateTime> {
 
 	private static final DateTimeFormatter formatter = new DateTimeFormatterBuilder().appendPattern("yyyy-MM-dd'T'HH:mm:ss")
-			.optionalStart().appendFraction(ChronoField.MILLI_OF_SECOND, 0, 3, true).optionalEnd()
+			.optionalStart().appendFraction(ChronoField.NANO_OF_SECOND, 0, 9, true).optionalEnd()
 			.optionalStart().appendPattern("XXXXX")
             .optionalEnd()
 			

--- a/src/main/java/org/rutebanken/util/LocalTimeISO8601XmlAdapter.java
+++ b/src/main/java/org/rutebanken/util/LocalTimeISO8601XmlAdapter.java
@@ -27,7 +27,7 @@ import java.util.concurrent.ConcurrentHashMap;
 public class LocalTimeISO8601XmlAdapter extends XmlAdapter<String, LocalTime> {
 
 	private static final DateTimeFormatter formatter = new DateTimeFormatterBuilder().appendPattern("HH:mm:ss")
-			.optionalStart().appendFraction(ChronoField.MILLI_OF_SECOND, 0, 3, true).optionalEnd()
+			.optionalStart().appendFraction(ChronoField.NANO_OF_SECOND, 0, 9, true).optionalEnd()
 			.optionalStart().appendPattern("XXXXX")
             .optionalEnd()
 

--- a/src/test/java/org/rutebanken/util/LocalDateTimeISO8601XmlAdapterTest.java
+++ b/src/test/java/org/rutebanken/util/LocalDateTimeISO8601XmlAdapterTest.java
@@ -1,0 +1,77 @@
+package org.rutebanken.util;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class LocalDateTimeISO8601XmlAdapterTest {
+
+    private final LocalDateTimeISO8601XmlAdapter adapter = new LocalDateTimeISO8601XmlAdapter();
+
+    @Test
+    void testUnmarshalBasicDateTime() {
+        LocalDateTime result = adapter.unmarshal("2026-08-31T00:00:00");
+        assertEquals(LocalDateTime.of(2026, 8, 31, 0, 0, 0), result);
+    }
+
+    @Test
+    void testUnmarshalDateTimeWithMilliseconds() {
+        LocalDateTime result = adapter.unmarshal("2026-05-03T23:30:09.398");
+        assertEquals(LocalDateTime.of(2026, 5, 3, 23, 30, 9, 398_000_000), result);
+    }
+
+    @Test
+    void testUnmarshalDateTimeWithOffset() {
+        LocalDateTime result = adapter.unmarshal("2026-05-03T23:30:09+02:00");
+        assertEquals(LocalDateTime.of(2026, 5, 3, 23, 30, 9), result);
+    }
+
+    @Test
+    void testUnmarshalDateTimeWithMicroseconds() {
+        LocalDateTime result = adapter.unmarshal("2026-05-03T23:30:09.398629");
+        assertEquals(LocalDateTime.of(2026, 5, 3, 23, 30, 9, 398_629_000), result);
+    }
+
+    @Test
+    void testUnmarshalDateTimeWithMicrosecondsAndOffset() {
+        LocalDateTime result = adapter.unmarshal("2026-05-03T23:30:09.398629+02:00");
+        assertEquals(LocalDateTime.of(2026, 5, 3, 23, 30, 9, 398_629_000), result);
+    }
+
+    @Test
+    void testUnmarshalDateTimeWithNanoseconds() {
+        LocalDateTime result = adapter.unmarshal("2026-05-03T23:30:09.123456789+02:00");
+        assertEquals(LocalDateTime.of(2026, 5, 3, 23, 30, 9, 123_456_789), result);
+    }
+
+    @Test
+    void testMarshalBasicDateTime() {
+        String result = adapter.marshal(LocalDateTime.of(2026, 8, 31, 0, 0, 0));
+        assertEquals("2026-08-31T00:00:00", result);
+    }
+
+    @Test
+    void testMarshalDateTimeWithMilliseconds() {
+        String result = adapter.marshal(LocalDateTime.of(2026, 5, 3, 23, 30, 9, 398_000_000));
+        assertEquals("2026-05-03T23:30:09.398", result);
+    }
+
+    @Test
+    void testMarshalDateTimeWithMicroseconds() {
+        String result = adapter.marshal(LocalDateTime.of(2026, 5, 3, 23, 30, 9, 398_629_000));
+        assertEquals("2026-05-03T23:30:09.398629", result);
+    }
+
+    @Test
+    void testMarshalNull() {
+        assertNull(adapter.marshal(null));
+    }
+
+    @Test
+    void testRoundTripWithMicroseconds() {
+        LocalDateTime original = LocalDateTime.of(2026, 5, 3, 23, 30, 9, 398_629_000);
+        assertEquals(original, adapter.unmarshal(adapter.marshal(original)));
+    }
+}

--- a/src/test/java/org/rutebanken/util/LocalTimeISO8601XmlAdapterTest.java
+++ b/src/test/java/org/rutebanken/util/LocalTimeISO8601XmlAdapterTest.java
@@ -37,6 +37,24 @@ public class LocalTimeISO8601XmlAdapterTest {
     }
 
     @Test
+    public void testUnmarshalTimeWithMicroseconds() {
+        LocalTime result = adapter.unmarshal("07:55:00.398629");
+        assertEquals(LocalTime.of(7, 55, 0, 398_629_000), result);
+    }
+
+    @Test
+    public void testUnmarshalTimeWithMicrosecondsAndOffset() {
+        LocalTime result = adapter.unmarshal("07:55:00.398629+02:00");
+        assertEquals(LocalTime.of(7, 55, 0, 398_629_000), result);
+    }
+
+    @Test
+    public void testUnmarshalTimeWithNanoseconds() {
+        LocalTime result = adapter.unmarshal("07:55:00.123456789+02:00");
+        assertEquals(LocalTime.of(7, 55, 0, 123_456_789), result);
+    }
+
+    @Test
     public void testUnmarshalMidnight() {
         LocalTime result = adapter.unmarshal("00:00:00");
         assertEquals(LocalTime.MIDNIGHT, result);
@@ -67,6 +85,12 @@ public class LocalTimeISO8601XmlAdapterTest {
     }
 
     @Test
+    public void testMarshalTimeWithMicroseconds() {
+        String result = adapter.marshal(LocalTime.of(7, 55, 0, 398_629_000));
+        assertEquals("07:55:00.398629", result);
+    }
+
+    @Test
     public void testMarshalMidnight() {
         String result = adapter.marshal(LocalTime.MIDNIGHT);
         assertEquals("00:00:00", result);
@@ -90,6 +114,12 @@ public class LocalTimeISO8601XmlAdapterTest {
         String marshalled = adapter.marshal(original);
         LocalTime unmarshalled = adapter.unmarshal(marshalled);
         assertEquals(original, unmarshalled);
+    }
+
+    @Test
+    public void testRoundTripWithMicroseconds() {
+        LocalTime original = LocalTime.of(7, 55, 0, 398_629_000);
+        assertEquals(original, adapter.unmarshal(adapter.marshal(original)));
     }
 
     @Test


### PR DESCRIPTION
`xs:dateTime` places no limit on the number of fractional-second digits, but the
parse formatter in `LocalDateTimeISO8601XmlAdapter` accepts at most three:

```java
.appendFraction(ChronoField.MILLI_OF_SECOND, 0, 3, true)
```

A schema-valid timestamp carrying microseconds therefore fails to parse. Because
JAXB routes the resulting `DateTimeParseException` through the default
`ValidationEventHandler`, the property is simply left unset — so downstream
consumers see a silent `null` rather than an error.

This was hit in the wild by OpenTripPlanner on an Italian NeTEx dataset
(opentripplanner/OpenTripPlanner#7956), where a `UicOperatingPeriod` was
discarded because its `FromDate` was dropped:

```xml
<UicOperatingPeriod version="153" id="IT:ITH4:UicOperatingPeriod:U182_20260416_0">
  <FromDate>2026-05-03T23:30:09.398629+02:00</FromDate>
  <ToDate>2026-08-31T00:00:00</ToDate>
  <ValidDayBits>1111110111111011111101111110101111011111001111100111110011111001111100111110011111001111100111110011111001111100111110011111001</ValidDayBits>
</UicOperatingPeriod>
```

Note that the `+02:00` offset is *not* the problem — the formatter already has an
optional offset section and discards it, which is the long-standing deliberate
behaviour discussed in #4. It is the six-digit fraction that fails.

## The change

One line — widen the fraction to nanosecond precision:

```diff
-.optionalStart().appendFraction(ChronoField.MILLI_OF_SECOND, 0, 3, true).optionalEnd()
+.optionalStart().appendFraction(ChronoField.NANO_OF_SECOND, 0, 9, true).optionalEnd()
```

Both the field and the width have to change. Widening the width alone — as
proposed in #41 — makes parsing succeed but silently truncates, because
`MILLI_OF_SECOND` can only carry three digits:

| input | `MILLI_OF_SECOND, 0, 9` (#41) | `NANO_OF_SECOND, 0, 9` (here) |
|---|---|---|
| `...09.398629+02:00` | `...09.398` (truncated) | `...09.398629` |
| `...00.012345+01:00` | `...00.012` (truncated) | `...00.012345` |

## Compatibility

Marshalled output is unchanged for every value that can round-trip today. The
fraction stays optional and minimal-width, so whole seconds still emit
`2026-08-31T00:00:00` and milliseconds still emit `...09.398`. Output differs
only for `LocalDateTime` values carrying sub-millisecond precision — which
currently cannot enter the model through unmarshalling at all, since they throw.
The wider format only preserves precision that is presently discarded.

There is no measurable parse cost; `maxWidth` bounds the digit loop rather than
adding work. If anything this is faster on the affected input, since it replaces
exception construction with a successful parse.

## Prior discussion

- #41 (2022) proposed the same fix for the same reason ("real-life fares data
  exists that has more than 3 digits"). It received no review and was closed
  unmerged.
- #294 includes this among a broader set of relaxations. Most of that PR accepts
  input that is *not* schema-valid, which is the basis on which it was
  questioned. This case is the exception: the example above validates against the
  official NeTEx schema and still fails to parse, as demonstrated by
  @stjugi in
  https://github.com/entur/netex-java-model/pull/294#issuecomment-4951382324.
  This PR takes only that piece and leaves the rest of #294 untouched.

## Not addressed here

`parseDefaulting(OFFSET_SECONDS, OffsetDateTime.now()...)` is evaluated once at
class-initialisation, baking the JVM's startup offset into a static field, so a
long-running process that crosses a DST boundary keeps a stale offset. It is
also redundant, since the parse target is a `LocalDateTime` and the offset is
discarded either way. 