### PR TITLE
Fix Sonar scan: remove stale sonar-maven-plugin override

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -681,7 +681,6 @@
 
             <properties>
                 <jdk.version>11</jdk.version>
-                <sonar-maven-plugin.version>3.9.1.2184</sonar-maven-plugin.version>
             </properties>
 
             <build>


### PR DESCRIPTION
## Problem

The Sonar scan step fails in CI (e.g. on #298):

```
[ERROR] Failed to execute goal org.sonarsource.scanner.maven:sonar-maven-plugin:3.9.1.2184:sonar
(default-cli) on project netex-java-model: Java 17 is not supported. Please upgrade to Java 21 or
newer, or use JRE auto-provisioning to keep this requirement always up to date.
```

## Cause

`pom.xml` declares `<sonar-maven-plugin.version>5.5.0.6356</sonar-maven-plugin.version>` in the
top-level properties, but the `sonar` profile overrode it back to `3.9.1.2184`. The CI Sonar step
runs with `-Psonar`, so the ancient scanner was the one actually used — and 3.9.1 has no JRE
auto-provisioning, so it fails outright now that SonarQube Cloud requires Java 21 or newer.

## Fix

Drop the override so the `sonar` profile uses the 5.5.0.6356 already declared at the top of the pom.
Scanner 5.5 runs on Java 17 and auto-provisions a JRE 21 for the analysis engine, so
`setup-java: 17` in `deploy.yml` can stay as is.

## Verification

- `mvn -Psonar help:evaluate -Dexpression=sonar-maven-plugin.version` → `5.5.0.6356`
- Ran `mvn -Psonar sonar:sonar` locally under JDK 17 against an unreachable host: it loads
  `sonar-maven-plugin:5.5.0.6356`, logs `Java 17.0.20 Ubuntu (64-bit)` and reaches server
  bootstrapping (failing only on the deliberate connection error) — no "Java 17 is not supported".