### PR TITLE
Skip repetetive LocalDate parsing

### DIFF
--- a/src/main/java/org/rutebanken/util/LocalTimeISO8601XmlAdapter.java
+++ b/src/main/java/org/rutebanken/util/LocalTimeISO8601XmlAdapter.java
@@ -22,7 +22,7 @@ import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
 import java.time.temporal.ChronoField;
 import java.util.HashMap;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.Map;
 
 public class LocalTimeISO8601XmlAdapter extends XmlAdapter<String, LocalTime> {
 
@@ -34,21 +34,39 @@ public class LocalTimeISO8601XmlAdapter extends XmlAdapter<String, LocalTime> {
 //
 	.parseDefaulting(ChronoField.OFFSET_SECONDS,OffsetDateTime.now().getLong(ChronoField.OFFSET_SECONDS) ).toFormatter();
 
+	private static final int SECONDS_PER_DAY = 24 * 60 * 60;
 	/**
-	 * We store a cache of parsed LocalTime instances to avoid wasting memory in immutable value
-	 * objects that strictly identical and interchangeable.
-	 *
-	 * We only cache times that are full seconds to avoid increasing the size of the cache unduly,
-	 * since there is a limited number of seconds in a single day.
+	 * Parsing a LocalTime with a DateTimeFormatter is expensive and shows up in real-world
+	 * profiles, since NeTEx documents contain a huge number of time values. Since there are only
+	 * 86400 distinct whole-second times in a day, we precompute all of them once: as canonical
+	 * LocalTime instances indexed by second-of-day (for reuse/dedup), and by their formatted
+	 * string representation (for a direct lookup that bypasses the parser entirely for the common
+	 * "HH:mm:ss" case).
 	 */
-	private final ConcurrentHashMap<LocalTime, LocalTime> cache = new ConcurrentHashMap<>();
+	private static final LocalTime[] TIMES_BY_SECOND_OF_DAY = new LocalTime[SECONDS_PER_DAY];
+	private static final Map<String, LocalTime> TIME_BY_STRING = new HashMap<>(SECONDS_PER_DAY * 2);
+
+	static {
+		for (int secondOfDay = 0; secondOfDay < SECONDS_PER_DAY; secondOfDay++) {
+			LocalTime time = LocalTime.ofSecondOfDay(secondOfDay);
+			TIMES_BY_SECOND_OF_DAY[secondOfDay] = time;
+			TIME_BY_STRING.put(formatter.format(time), time);
+		}
+	}
 
 	@Override
 	public LocalTime unmarshal(String input) {
+		// fast path: avoid the DateTimeFormatter parser entirely for plain whole-second times
+		LocalTime cached = TIME_BY_STRING.get(input);
+		if (cached != null) {
+			return cached;
+		}
+
 		var key = LocalTime.parse(input, formatter);
-		// only cache if nano is zero
-		if(key.getNano() == 0){
-			return cache.computeIfAbsent(key, time -> time);
+		// only reuse the cached instance if nano is zero, so as not to increase the size of the
+		// cache unduly, since there is a limited number of seconds in a single day
+		if (key.getNano() == 0) {
+			return TIMES_BY_SECOND_OF_DAY[key.toSecondOfDay()];
 		}
 		// sub-second times are not cached to not increase the size of the cache unduly
 		else {

--- a/src/test/java/org/rutebanken/util/LocalTimeISO8601XmlAdapterTest.java
+++ b/src/test/java/org/rutebanken/util/LocalTimeISO8601XmlAdapterTest.java
@@ -146,4 +146,43 @@ public class LocalTimeISO8601XmlAdapterTest {
 
         parsed.forEach(time -> assertSame(first, time, "Same time value should return same instance"));
     }
+
+    @Test
+    public void testFastPathReturnsSameInstanceAsParsedEquivalent() {
+        // "10:20:30" is a plain "HH:mm:ss" string that hits the precomputed second-of-day cache
+        // directly, without ever going through the DateTimeFormatter parser. Values that must go
+        // through the parser (offset, fractional zero) should still resolve to that same cached
+        // instance rather than a freshly parsed, distinct object.
+        LocalTime fastPath = adapter.unmarshal("10:20:30");
+        LocalTime viaOffset = adapter.unmarshal("10:20:30+02:00");
+        LocalTime viaFraction = adapter.unmarshal("10:20:30.000");
+        LocalTime viaFractionAndOffset = adapter.unmarshal("10:20:30.000-05:00");
+
+        assertSame(fastPath, viaOffset);
+        assertSame(fastPath, viaFraction);
+        assertSame(fastPath, viaFractionAndOffset);
+    }
+
+    @Test
+    public void testEverySecondOfTheDayIsCachedAndConsistent() {
+        for (int secondOfDay = 0; secondOfDay < 24 * 60 * 60; secondOfDay += 37) {
+            LocalTime expected = LocalTime.ofSecondOfDay(secondOfDay);
+            String input = String.format("%02d:%02d:%02d", expected.getHour(), expected.getMinute(), expected.getSecond());
+
+            LocalTime first = adapter.unmarshal(input);
+            LocalTime second = adapter.unmarshal(input);
+
+            assertEquals(expected, first);
+            assertSame(first, second, "Repeated unmarshal of '" + input + "' should return the cached instance");
+        }
+    }
+
+    @Test
+    public void testSubSecondTimesAreNotCached() {
+        LocalTime first = adapter.unmarshal("18:00:00.001");
+        LocalTime second = adapter.unmarshal("18:00:00.001");
+
+        assertEquals(first, second);
+        assertNotSame(first, second, "Sub-second times should not be served from the whole-second cache");
+    }
 }


### PR DESCRIPTION
## Summary                                                                                                                                  
                                                                                                                                              
  `LocalTimeISO8601XmlAdapter.unmarshal` was showing up in real-world profiling as a hotspot: NeTEx documents contain a very large number of `LocalTime` values, and every one of them was going through `DateTimeFormatter.parse`, which is comparatively expensive.                    
                                                                                                                                              
Since a day only has 86,400 distinct whole-second times, this PR precomputes all of them once at class-load time:                           
                                                                                                                                              
  - `TIMES_BY_SECOND_OF_DAY` — a `LocalTime[86400]` array indexed by second-of-day, used to hand back a canonical, deduplicated instance.     
  - `TIME_BY_STRING` — a `Map<String, LocalTime>` from the formatted `"HH:mm:ss"` string to that same canonical instance.                     

### Flame graph

#### Before
<img width="2357" height="898" alt="image" src="https://github.com/user-attachments/assets/cd0b6481-7d6f-47e4-beea-ccf73fecac63" />

#### After

<img width="2357" height="898" alt="image" src="https://github.com/user-attachments/assets/2372f52d-0e43-43ec-a31f-25e69637cdf5" />


## Real-world improvement                                                                                        

When using this improvement in an OTP graph build with a very large (50GB!) NeTEx feed this leads to some very noticeable graph build improvements.

#### Before

```
Graph building took 18m58s697ms.
```

#### After

```
Graph building took 17m28s267ms
```

So 90 seconds was spent in repeatedly parsing LocalTimes!
                                                                                                                                              
## Memory tradeoff                                                                                                                          
                                                                                                                                              
The previous cache was a `ConcurrentHashMap` populated lazily — it only held entries for times actually seen, so a typical document with a  handful of distinct times cost next to nothing.                                                                                             
                                                                                                                                              
The new cache is precomputed unconditionally at class-load time, so it always costs the same, whether or not the times are ever used. `TIME_BY_STRING` is built into a temporary `HashMap` and then frozen with `Map.copyOf`, so the field is immutable and, as a bonus, its compact array-based representation (no per-entry `Node` objects) uses noticeably less memory than a live `HashMap` of the same size.

Measured via heap-delta on class load:

 - Old adapter (lazy cache, empty at startup): ~2.3 MB (mostly `DateTimeFormatter` class loading)
 - New adapter, precomputed cache in a mutable `HashMap`: ~13.5 MB
 - New adapter, precomputed cache frozen with `Map.copyOf` (this PR): ~10.8 MB

**Net additional cost: ~8.5 MB, permanent for the life of the JVM** — about 2.5-3 MB less than a plain `HashMap` would cost, on top of being immutable. This is a fixed one-time cost, not per-instance, and trivial relative to typical heap sizes — but worth calling out since it's paid upfront rather than proportionally to usage.

cc @flaktack

Ref: https://github.com/noi-techpark/opendatahub-mentor-otp/issues/330
